### PR TITLE
fix(mobile): stop the chat view paging itself into the middle of a session

### DIFF
--- a/.claude/skills/upstream-sync/SKILL.md
+++ b/.claude/skills/upstream-sync/SKILL.md
@@ -166,11 +166,20 @@ and check a suspect against the pre-sync branch before treating it as new.
 
 Two things the sync itself will not tell you:
 
-- **The version follows upstream's line.** Read their newest tag
-  (`git tag -l 'v*' --sort=-v:refname | head -1`), not `package.json` on their
-  main — their release-cut writes the version in a separate commit, so main
-  always lags. After 79 commits on 23 August, upstream's newest was `v1.4.188`,
-  so this fork went to `1.4.189-rc.0`.
+- **The version follows upstream's line.** Read their newest tag, not
+  `package.json` on their main — their release-cut writes the version in a
+  separate commit, so main always lags. After 79 commits on 23 August,
+  upstream's newest was `v1.4.188`, so this fork went to `1.4.189-rc.0`.
+
+  Ask the remote, not the local tag list. `git fetch upstream --tags` pulls
+  2000+ of their tags in beside this fork's own, and `git tag -l` then reports
+  whichever sorts highest — on 25 August that was `v1.4.189-rc.6`, which is
+  *ours*. Upstream was still on `v1.4.188`.
+
+  ```bash
+  git ls-remote --tags upstream | grep -v '\^{}' |
+    grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$' | sort -V | tail -1
+  ```
 - **Skill revisions need sealing at the new version.** Compare
   `resources/skills/current-manifest.json` against the last row of
   `release-mapping.json`; if they disagree, run
@@ -178,7 +187,33 @@ Two things the sync itself will not tell you:
   Left unsealed, the next regeneration reassigns a revision number to different
   bytes and every installed copy stops matching a known snapshot.
 
-Then merge into `main` and cut the tag per `docs/reference/release-secrets.md`.
+## Landing it
+
+**Open a pull request. Do not push the sync straight to `main`.**
+
+Nothing in this repo's CI runs on a push to `main` — `pr.yml` and `mobile.yml`
+both trigger on `pull_request` only, and the release workflow builds without
+testing. A sync pushed directly is a few hundred files that no CI has ever
+seen; the 25 August one landed that way and its only evidence was a local
+test run.
+
+`mobile.yml` matters most here, because it is the only job that loads the
+Fastfile — the iOS signing config and the NSE target's provisioning. A local
+`vitest` pass over `mobile/` does not cover any of that, and this sync changed
+67 files under `mobile/`.
+
+```bash
+git push -u origin sync/upstream-<date>
+gh pr create --repo <fork> --base main --fill
+gh pr checks --repo <fork> --watch
+```
+
+Merge once the checks are green, then cut the tag per
+`docs/reference/release-secrets.md`.
+
+Push the tag only after `main` is where you want it. Pushing the tag first and
+rebasing afterwards leaves the tag on an orphaned commit, and moving it means
+force-updating a ref that a published release already points at.
 
 ## What this fork owns
 

--- a/mobile/src/components/NewWorkspaceSetupScriptField.tsx
+++ b/mobile/src/components/NewWorkspaceSetupScriptField.tsx
@@ -25,11 +25,15 @@ export function NewWorkspaceSetupScriptField({
   return (
     <View style={styles.field}>
       <View style={styles.setupHeader}>
-        <Text style={styles.label}>{translate('m.NewWorktreeModal.d1c6e46d31', 'Setup script')}</Text>
+        <Text style={styles.label}>
+          {translate('m.NewWorktreeModal.d1c6e46d31', 'Setup script')}
+        </Text>
         {source ? (
           <View style={styles.sourceBadge}>
             <Text style={styles.sourceBadgeText}>
-              {source === 'manta.yaml' ? translate('m.NewWorktreeModal.2c40d1cbfe', 'MANTA.YAML') : translate('m.NewWorktreeModal.f1c9144d48', 'HOOKS')}
+              {source === 'manta.yaml'
+                ? translate('m.NewWorktreeModal.2c40d1cbfe', 'MANTA.YAML')
+                : translate('m.NewWorktreeModal.f1c9144d48', 'HOOKS')}
             </Text>
           </View>
         ) : null}
@@ -44,7 +48,9 @@ export function NewWorkspaceSetupScriptField({
               ]}
               onPress={() => onDecisionChange('run')}
             >
-              <Text style={styles.setupChoiceText}>{translate('m.NewWorktreeModal.d2a6322022', 'Run')}</Text>
+              <Text style={styles.setupChoiceText}>
+                {translate('m.NewWorktreeModal.d2a6322022', 'Run')}
+              </Text>
             </Pressable>
             <Pressable
               style={[
@@ -53,12 +59,16 @@ export function NewWorkspaceSetupScriptField({
               ]}
               onPress={() => onDecisionChange('skip')}
             >
-              <Text style={styles.setupChoiceText}>{translate('m.NewWorktreeModal.b191daf935', 'Skip')}</Text>
+              <Text style={styles.setupChoiceText}>
+                {translate('m.NewWorktreeModal.b191daf935', 'Skip')}
+              </Text>
             </Pressable>
           </View>
         ) : (
           <View style={styles.setupToggleRow}>
-            <Text style={styles.setupToggleLabel}>{translate('m.NewWorktreeModal.a1b2e6ce4c', 'Run setup command')}</Text>
+            <Text style={styles.setupToggleLabel}>
+              {translate('m.NewWorktreeModal.a1b2e6ce4c', 'Run setup command')}
+            </Text>
             <Switch
               value={runSetup}
               onValueChange={onRunSetupChange}

--- a/mobile/src/components/NewWorkspaceSshConnectionField.tsx
+++ b/mobile/src/components/NewWorkspaceSshConnectionField.tsx
@@ -15,7 +15,9 @@ export function NewWorkspaceSshConnectionField({
 }) {
   return (
     <View style={styles.field}>
-      <Text style={styles.label}>{translate('m.NewWorktreeModal.24d0c3cf77', 'SSH Connection')}</Text>
+      <Text style={styles.label}>
+        {translate('m.NewWorktreeModal.24d0c3cf77', 'SSH Connection')}
+      </Text>
       <View style={styles.sshBox}>
         <View style={styles.sshRow}>
           <View
@@ -41,7 +43,9 @@ export function NewWorkspaceSshConnectionField({
               onPress={onConnect}
             >
               <Text style={styles.sshConnectText}>
-                {sshGate.connectInProgress ? translate('m.NewWorktreeModal.a2ba0ebe73', 'Connecting...') : translate('m.NewWorktreeModal.3bddecbdf9', 'Connect')}
+                {sshGate.connectInProgress
+                  ? translate('m.NewWorktreeModal.a2ba0ebe73', 'Connecting...')
+                  : translate('m.NewWorktreeModal.3bddecbdf9', 'Connect')}
               </Text>
             </Pressable>
           )}

--- a/mobile/src/components/NewWorktreeFormSheet.tsx
+++ b/mobile/src/components/NewWorktreeFormSheet.tsx
@@ -59,7 +59,9 @@ export function NewWorktreeFormSheet(props: {
   return (
     <BottomDrawer visible={props.visible} interactive={props.interactive} onClose={props.onClose}>
       <View style={styles.header}>
-        <Text style={styles.title}>{translate('m.NewWorktreeModal.52a6d084dc', 'Create worktree')}</Text>
+        <Text style={styles.title}>
+          {translate('m.NewWorktreeModal.52a6d084dc', 'Create worktree')}
+        </Text>
       </View>
 
       {props.loading ? (
@@ -68,7 +70,9 @@ export function NewWorktreeFormSheet(props: {
         </View>
       ) : !props.hasRepos ? (
         <View style={styles.loadingContainer}>
-          <Text style={styles.emptyText}>{translate('m.NewWorktreeModal.47a5edf943', 'No projects found')}</Text>
+          <Text style={styles.emptyText}>
+            {translate('m.NewWorktreeModal.47a5edf943', 'No projects found')}
+          </Text>
         </View>
       ) : (
         <>
@@ -82,7 +86,11 @@ export function NewWorktreeFormSheet(props: {
 
           <SmartWorkspaceSourceField
             composer={props.composer}
-            label={props.selectedRepoIsGit ? translate('m.NewWorktreeModal.cb29993224', 'Name or \'Create From\'') : translate('m.NewWorktreeModal.1054d2ae92', 'Workspace name')}
+            label={
+              props.selectedRepoIsGit
+                ? translate('m.NewWorktreeModal.cb29993224', "Name or 'Create From'")
+                : translate('m.NewWorktreeModal.1054d2ae92', 'Workspace name')
+            }
             disabled={props.sshGate.requiresConnection}
             interactive={props.interactive}
             onBeforeOpen={props.onClearError}
@@ -122,7 +130,9 @@ export function NewWorktreeFormSheet(props: {
             style={styles.advancedToggle}
             onPress={() => props.onShowAdvancedChange(!props.showAdvanced)}
           >
-            <Text style={styles.advancedText}>{translate('m.NewWorktreeModal.013a3be8ad', 'Advanced')}</Text>
+            <Text style={styles.advancedText}>
+              {translate('m.NewWorktreeModal.013a3be8ad', 'Advanced')}
+            </Text>
             {props.showAdvanced ? (
               <ChevronUp size={14} color={colors.textSecondary} />
             ) : (
@@ -137,7 +147,9 @@ export function NewWorktreeFormSheet(props: {
                 selectedRepoIsGit={props.selectedRepoIsGit}
               />
               <View style={styles.field}>
-                <Text style={styles.label}>{translate('m.NewWorktreeModal.2cc02a28d4', 'Note')}</Text>
+                <Text style={styles.label}>
+                  {translate('m.NewWorktreeModal.2cc02a28d4', 'Note')}
+                </Text>
                 <TextInput
                   style={styles.input}
                   value={props.note}
@@ -173,7 +185,9 @@ export function NewWorktreeFormSheet(props: {
                 <ActivityIndicator size="small" color={colors.bgBase} />
               ) : (
                 <Text style={styles.createText}>
-                  {props.sshGate.requiresConnection ? translate('m.NewWorktreeModal.8a9197a7a9', 'Connect target') : translate('m.NewWorktreeModal.52a6d084dc', 'Create worktree')}
+                  {props.sshGate.requiresConnection
+                    ? translate('m.NewWorktreeModal.8a9197a7a9', 'Connect target')
+                    : translate('m.NewWorktreeModal.52a6d084dc', 'Create worktree')}
                 </Text>
               )}
             </Pressable>

--- a/mobile/src/components/NewWorktreeModal.tsx
+++ b/mobile/src/components/NewWorktreeModal.tsx
@@ -201,7 +201,10 @@ function NewWorktreeModalContent(props: NewWorktreeModalProps) {
         projectBadgeColor={selectedRepo ? getMobileWorkspaceRepoBadgeColor(selectedRepo) : null}
         selectedRepoIsGit={selectedRepoIsGit}
         selectedRepoConnectionId={selectedRepoConnectionId}
-        selectedRepoName={selectedRepo?.displayName ?? translate('m.NewWorktreeModal.02690f5980', 'Remote repository')}
+        selectedRepoName={
+          selectedRepo?.displayName ??
+          translate('m.NewWorktreeModal.02690f5980', 'Remote repository')
+        }
         sshGate={executionTarget.sshGate}
         composer={composer}
         selectedAgent={agentSelection.selectedAgent}

--- a/mobile/src/components/use-new-workspace-create-submit.ts
+++ b/mobile/src/components/use-new-workspace-create-submit.ts
@@ -143,7 +143,10 @@ export function useNewWorkspaceCreateSubmit(args: {
           repoName: selectedRepo.displayName,
           scriptContent: args.setupTrust.scriptContent,
           contentHash: args.setupTrust.contentHash,
-          previouslyApproved: wasSetupHookPreviouslyApproved(args.trustedMantaHooks, selectedRepo.id)
+          previouslyApproved: wasSetupHookPreviouslyApproved(
+            args.trustedMantaHooks,
+            selectedRepo.id
+          )
         })
         args.transitionDrawer('trust')
         return

--- a/mobile/src/components/use-new-workspace-execution-target.ts
+++ b/mobile/src/components/use-new-workspace-execution-target.ts
@@ -126,7 +126,9 @@ export function useNewWorkspaceExecutionTarget(args: {
         fallbackSshState(
           connectionId,
           'error',
-          error instanceof Error ? error.message : translate('m.NewWorktreeModal.1588fda823', 'Failed to connect to SSH repository.')
+          error instanceof Error
+            ? error.message
+            : translate('m.NewWorktreeModal.1588fda823', 'Failed to connect to SSH repository.')
         )
       )
     } finally {

--- a/mobile/src/components/use-new-workspace-runtime-context.ts
+++ b/mobile/src/components/use-new-workspace-runtime-context.ts
@@ -59,7 +59,8 @@ export function useNewWorkspaceRuntimeContext(
       }
       const uiResult = settledSuccess(uiRes)
       if (uiResult) {
-        const ui = (uiResult.result as { ui?: { trustedMantaHooks?: PersistedTrustedMantaHooks } }).ui
+        const ui = (uiResult.result as { ui?: { trustedMantaHooks?: PersistedTrustedMantaHooks } })
+          .ui
         setTrustedMantaHooks(ui?.trustedMantaHooks ?? {})
       }
 

--- a/mobile/src/home/MobileHomeEmptyState.tsx
+++ b/mobile/src/home/MobileHomeEmptyState.tsx
@@ -14,7 +14,7 @@ function onboardingSteps() {
       desc: 'Tap the button above to open the scanner. Point at the QR code on your screen.'
     },
     {
-      title: translate('m.index.aea01b53db', 'You\'re connected'),
+      title: translate('m.index.aea01b53db', "You're connected"),
       desc: 'Your desktop will appear here. Everything is encrypted end-to-end.'
     }
   ]
@@ -39,11 +39,20 @@ export function MobileHomeEmptyState(props: {
       ]}
     >
       <View style={styles.emptyHero}>
-        <Text style={styles.emptyTitle}>{translate('m.index.f2f89ea971', 'Connect your desktop')}</Text>
-        <Text style={styles.emptyBody}>{translate('m.index.bf2694d8a7', "Pair with Manta on your computer to check on your agents, jump into any terminal, and drive work from your phone.")}</Text>
+        <Text style={styles.emptyTitle}>
+          {translate('m.index.f2f89ea971', 'Connect your desktop')}
+        </Text>
+        <Text style={styles.emptyBody}>
+          {translate(
+            'm.index.bf2694d8a7',
+            'Pair with Manta on your computer to check on your agents, jump into any terminal, and drive work from your phone.'
+          )}
+        </Text>
         <Pressable style={styles.primaryButton} onPress={props.onPairDesktop}>
           <QrCode size={17} color={colors.bgBase} />
-          <Text style={styles.primaryButtonText}>{translate('m.index.956aabb1b3', 'Pair Desktop')}</Text>
+          <Text style={styles.primaryButtonText}>
+            {translate('m.index.956aabb1b3', 'Pair Desktop')}
+          </Text>
         </Pressable>
       </View>
       <View style={styles.stepsSection}>

--- a/mobile/src/home/MobileHomeListHeader.tsx
+++ b/mobile/src/home/MobileHomeListHeader.tsx
@@ -25,7 +25,9 @@ export function MobileHomeListHeader({ stats }: { stats: HomeStatsSummary | null
         <View style={styles.statsRow}>
           <View style={styles.statCard}>
             <Text style={styles.statValue}>{stats.totalAgentsSpawned.toLocaleString()}</Text>
-            <Text style={styles.statLabel}>{translate('m.index.a8515b5dc4', 'Agents spawned')}</Text>
+            <Text style={styles.statLabel}>
+              {translate('m.index.a8515b5dc4', 'Agents spawned')}
+            </Text>
           </View>
           <View style={styles.statCard}>
             <Text style={styles.statValue}>{formatDuration(stats.totalAgentTimeMs)}</Text>

--- a/mobile/src/home/MobileHomeScreen.tsx
+++ b/mobile/src/home/MobileHomeScreen.tsx
@@ -83,7 +83,12 @@ export function MobileHomeScreen() {
     } else if (host.credentialStatus === 'temporarily-unavailable') {
       void loadHostCatalog()
         .then(data.setHostCatalog)
-        .catch(() => Alert.alert(translate('m.index.b10d78d179', 'Could not check pairing'), translate('m.index.18b828cf5b', 'Please try again.')))
+        .catch(() =>
+          Alert.alert(
+            translate('m.index.b10d78d179', 'Could not check pairing'),
+            translate('m.index.18b828cf5b', 'Please try again.')
+          )
+        )
     } else {
       data.router.push(`/h/${host.id}`)
     }
@@ -108,7 +113,10 @@ export function MobileHomeScreen() {
       data.setHostCatalog(await loadHostCatalog())
     } catch {
       setConfirmRemove(host)
-      Alert.alert(translate('m.index.53b5a5229a', 'Could not remove host'), translate('m.index.18b828cf5b', 'Please try again.'))
+      Alert.alert(
+        translate('m.index.53b5a5229a', 'Could not remove host'),
+        translate('m.index.18b828cf5b', 'Please try again.')
+      )
     }
   }
 
@@ -186,7 +194,9 @@ export function MobileHomeScreen() {
       <ConfirmModal
         visible={confirmRemove != null}
         title={translate('m.index.c8e253dc76', 'Remove Host')}
-        message={translate('m.index.a3cfae357a', "Remove \"{{value0}}\"? You can re-pair later.", { value0: confirmRemove?.name ?? '' })}
+        message={translate('m.index.a3cfae357a', 'Remove "{{value0}}"? You can re-pair later.', {
+          value0: confirmRemove?.name ?? ''
+        })}
         confirmLabel="Remove"
         destructive
         onConfirm={() => void handleRemove()}

--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -72,6 +72,9 @@ type Overrides = {
   inputLockReason?: 'disconnected' | 'waiting' | null
   onSend?: (text: string) => Promise<boolean>
   pending?: Parameters<typeof MobileNativeChatView>[0]['pending']
+  hasMore?: boolean
+  loadingEarlier?: boolean
+  onLoadEarlier?: () => void
 }
 
 function assistantTurn(id: string, text: string): NativeChatMessage {
@@ -241,4 +244,67 @@ describe('MobileNativeChatView', () => {
       vi.useRealTimers()
     }
   })
+  describe('paging in older history', () => {
+    function list(): ReactTestInstance {
+      return renderer!.root.find((node) => node.type === 'FlatList')
+    }
+
+    async function scrollTo(offsetY: number): Promise<void> {
+      await act(async () => {
+        list().props.onScroll({
+          nativeEvent: {
+            contentOffset: { y: offsetY },
+            contentSize: { height: 4000 },
+            layoutMeasurement: { height: 800 }
+          }
+        })
+      })
+    }
+
+    /**
+     * The view fires its own scrollToEnd on open, starting from offset 0. Its
+     * first throttled sample reads as "near the top", so a trigger that only
+     * looks at the offset pages in history nobody asked for — and because that
+     * prepends PAGE rows above the viewport, the reader lands mid-session.
+     */
+    it('does not page in history for a scroll the user did not start', async () => {
+      const onLoadEarlier = vi.fn()
+      await render({ messages: [assistantTurn('a', 'one')], hasMore: true, onLoadEarlier })
+
+      await scrollTo(10)
+
+      expect(onLoadEarlier).not.toHaveBeenCalled()
+    })
+
+    it('pages in history once the user drags to the top', async () => {
+      const onLoadEarlier = vi.fn()
+      await render({ messages: [assistantTurn('a', 'one')], hasMore: true, onLoadEarlier })
+
+      await act(async () => list().props.onScrollBeginDrag())
+      await scrollTo(10)
+
+      expect(onLoadEarlier).toHaveBeenCalledTimes(1)
+    })
+
+    it('stops paging again once the list comes to rest', async () => {
+      const onLoadEarlier = vi.fn()
+      await render({ messages: [assistantTurn('a', 'one')], hasMore: true, onLoadEarlier })
+
+      await act(async () => list().props.onScrollBeginDrag())
+      await scrollTo(10)
+      await act(async () => list().props.onMomentumScrollEnd())
+      await scrollTo(10)
+
+      expect(onLoadEarlier).toHaveBeenCalledTimes(1)
+    })
+
+    // A prepended page measures to whatever its rows render to, so without an
+    // anchor it pushes the reader down by that much.
+    it('anchors visible content so a prepend does not move the reader', async () => {
+      await render({ messages: [assistantTurn('a', 'one')], hasMore: true })
+
+      expect(list().props.maintainVisibleContentPosition).toEqual({ minIndexForVisible: 1 })
+    })
+  })
+
 })

--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -306,5 +306,4 @@ describe('MobileNativeChatView', () => {
       expect(list().props.maintainVisibleContentPosition).toEqual({ minIndexForVisible: 1 })
     })
   })
-
 })

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -196,7 +196,6 @@ export function MobileNativeChatView({
     [onSend, onClearSendError, scroll]
   )
 
-
   const renderItem = useCallback(
     ({ item, index }: { item: NativeChatMessage; index: number }) => (
       <MobileNativeChatMessage

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -1,13 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import {
-  ActivityIndicator,
-  FlatList,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
-  Pressable,
-  Text,
-  View
-} from 'react-native'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { ActivityIndicator, FlatList, Pressable, Text, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler'
 import { ArrowDown, ChevronsDownUp, ChevronsUpDown, Square } from 'lucide-react-native'
@@ -21,6 +13,7 @@ import {
   type MobileNativeChatPendingItem
 } from './mobile-native-chat-render-data'
 import { useMobileNativeChatPinchGesture } from './use-mobile-native-chat-pinch-gesture'
+import { useMobileNativeChatScroll } from './use-mobile-native-chat-scroll'
 import { MobileAgentWorkingIndicator } from './MobileAgentWorkingIndicator'
 import type { PendingNativeChatImage } from './mobile-native-chat-image-attachment'
 import { MobileNativeChatComposer } from './MobileNativeChatComposer'
@@ -159,26 +152,11 @@ export function MobileNativeChatView({
   keyboardInset = 0
 }: Props): React.JSX.Element {
   const insets = useSafeAreaInsets()
-  const listRef = useRef<FlatList<NativeChatMessage>>(null)
   const [toolsExpanded, setToolsExpanded] = useState(false)
   // Lift the composer clear of the keyboard, plus the bottom safe-area so it
   // never sits under the home indicator / nav bar (mirrors the terminal dock).
   const bottomPad = keyboardInset > 0 ? keyboardInset + insets.bottom : insets.bottom
-  const [atBottom, setAtBottom] = useState(true)
-  // Why: onScroll cannot tell a programmatic scrollToEnd from a drag, and the
-  // one this view fires on open starts at offset 0 — its first throttled sample
-  // reads as "near the top" and pages in history nobody asked for.
-  const userDraggingRef = useRef(false)
-  const sendScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const { fontScale, pinchGesture } = useMobileNativeChatPinchGesture()
-  useEffect(
-    () => () => {
-      if (sendScrollTimerRef.current) {
-        clearTimeout(sendScrollTimerRef.current)
-      }
-    },
-    []
-  )
 
   // `data` is the list source: folded transcript + synthetic streaming bubble +
   // route-owned accepted echoes. Memoize on the same deps so the
@@ -194,17 +172,13 @@ export function MobileNativeChatView({
     [folded, streaming, pending, imagePreviewsByMessageId]
   )
 
-  // Follow the tail as the conversation grows and keep the newest message above
-  // the keyboard when it opens — but only when already pinned to the bottom, so
-  // we don't yank the user away while they read history. (Also fires on keyboard
-  // close, which is harmless while atBottom.)
-  useEffect(() => {
-    if (data.length === 0 || !atBottom) {
-      return
-    }
-    const t = setTimeout(() => listRef.current?.scrollToEnd({ animated: true }), 60)
-    return () => clearTimeout(t)
-  }, [data.length, atBottom, keyboardInset])
+  const scroll = useMobileNativeChatScroll({
+    messageCount: data.length,
+    keyboardInset,
+    hasMore,
+    loadingEarlier,
+    onLoadEarlier
+  })
 
   const handleSend = useCallback(
     async (text: string): Promise<boolean> => {
@@ -216,36 +190,12 @@ export function MobileNativeChatView({
       // or a stale "Message not sent" sits above the delivered message.
       onClearSendError?.()
       // Always jump to the newest message when the user sends.
-      setAtBottom(true)
-      if (sendScrollTimerRef.current) {
-        clearTimeout(sendScrollTimerRef.current)
-      }
-      sendScrollTimerRef.current = setTimeout(() => {
-        sendScrollTimerRef.current = null
-        listRef.current?.scrollToEnd({ animated: true })
-      }, 60)
+      scroll.jumpToLatest()
       return true
     },
-    [onSend, onClearSendError]
+    [onSend, onClearSendError, scroll]
   )
 
-  const onScroll = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent
-      const distanceFromBottom = contentSize.height - (contentOffset.y + layoutMeasurement.height)
-      setAtBottom(distanceFromBottom < 80)
-      // Near the top — page in older history, but only if the user put us here.
-      if (userDraggingRef.current && contentOffset.y < 60 && hasMore && !loadingEarlier) {
-        onLoadEarlier?.()
-      }
-    },
-    [hasMore, loadingEarlier, onLoadEarlier]
-  )
-
-  // Align a single message's top to the top of the viewport.
-  const onScrollToMessage = useCallback((index: number) => {
-    listRef.current?.scrollToIndex({ index, viewPosition: 0, animated: true })
-  }, [])
 
   const renderItem = useCallback(
     ({ item, index }: { item: NativeChatMessage; index: number }) => (
@@ -254,11 +204,11 @@ export function MobileNativeChatView({
         toolsExpanded={toolsExpanded}
         fontScale={fontScale}
         messageIndex={index}
-        onScrollToMessage={onScrollToMessage}
+        onScrollToMessage={scroll.scrollToMessage}
         onOpenFile={onOpenFile}
       />
     ),
-    [toolsExpanded, fontScale, onScrollToMessage, onOpenFile]
+    [toolsExpanded, fontScale, scroll.scrollToMessage, onOpenFile]
   )
 
   const emptyState = mobileNativeChatEmptyState(status, agent ?? null, error)
@@ -287,7 +237,7 @@ export function MobileNativeChatView({
         <GestureHandlerRootView style={styles.listWrap}>
           <GestureDetector gesture={pinchGesture}>
             <FlatList
-              ref={listRef}
+              ref={scroll.listRef}
               data={data}
               keyExtractor={(item) => item.id}
               renderItem={renderItem}
@@ -295,46 +245,17 @@ export function MobileNativeChatView({
               // Let link/file taps land while the composer keyboard is up
               // instead of being swallowed by the dismiss gesture.
               keyboardShouldPersistTaps="handled"
-              onScroll={onScroll}
+              onScroll={scroll.onScroll}
               scrollEventThrottle={32}
-              onScrollBeginDrag={() => {
-                userDraggingRef.current = true
-              }}
-              // Momentum outlives the finger, and a fling from mid-list is still
-              // the user asking for history — so the flag clears only once the
-              // list is fully at rest.
-              onMomentumScrollEnd={() => {
-                userDraggingRef.current = false
-              }}
-              onScrollEndDrag={(e) => {
-                if (e.nativeEvent.velocity == null || e.nativeEvent.velocity.y === 0) {
-                  userDraggingRef.current = false
-                }
-              }}
-              // Why: paging in history prepends up to PAGE rows above the
-              // viewport. Without an anchor the reader is pushed down by
-              // whatever those rows measure to.
+              onScrollBeginDrag={scroll.onScrollBeginDrag}
+              onScrollEndDrag={scroll.onScrollEndDrag}
+              onMomentumScrollEnd={scroll.onMomentumScrollEnd}
+              // Why: paging in history prepends rows above the viewport.
+              // Without an anchor the reader is pushed down by whatever those
+              // rows measure to.
               maintainVisibleContentPosition={{ minIndexForVisible: 1 }}
-              onContentSizeChange={() => {
-                if (data.length > 0 && atBottom) {
-                  listRef.current?.scrollToEnd({ animated: false })
-                }
-              }}
-              // scrollToIndex can fail before an off-screen row is measured —
-              // fall back to an estimated offset, then retry once it's laid out.
-              onScrollToIndexFailed={(info) => {
-                listRef.current?.scrollToOffset({
-                  offset: info.averageItemLength * info.index,
-                  animated: true
-                })
-                setTimeout(() => {
-                  listRef.current?.scrollToIndex({
-                    index: info.index,
-                    viewPosition: 0,
-                    animated: true
-                  })
-                }, 120)
-              }}
+              onContentSizeChange={scroll.onContentSizeChange}
+              onScrollToIndexFailed={scroll.onScrollToIndexFailed}
               ListHeaderComponent={
                 hasMore ? (
                   <Pressable
@@ -364,11 +285,11 @@ export function MobileNativeChatView({
           </GestureDetector>
           {/* Jump-to-latest control. The scroll-to-top affordance now lives
               per-message (the up-arrow in each agent message's controls). */}
-          {!atBottom ? (
+          {!scroll.atBottom ? (
             <Pressable
               accessibilityLabel="Scroll to latest"
               style={[styles.fab, styles.fabBottom]}
-              onPress={() => listRef.current?.scrollToEnd({ animated: true })}
+              onPress={scroll.jumpToLatest}
             >
               <ArrowDown size={18} color={colors.textPrimary} strokeWidth={2.2} />
             </Pressable>

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -165,6 +165,10 @@ export function MobileNativeChatView({
   // never sits under the home indicator / nav bar (mirrors the terminal dock).
   const bottomPad = keyboardInset > 0 ? keyboardInset + insets.bottom : insets.bottom
   const [atBottom, setAtBottom] = useState(true)
+  // Why: onScroll cannot tell a programmatic scrollToEnd from a drag, and the
+  // one this view fires on open starts at offset 0 — its first throttled sample
+  // reads as "near the top" and pages in history nobody asked for.
+  const userDraggingRef = useRef(false)
   const sendScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const { fontScale, pinchGesture } = useMobileNativeChatPinchGesture()
   useEffect(
@@ -230,8 +234,8 @@ export function MobileNativeChatView({
       const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent
       const distanceFromBottom = contentSize.height - (contentOffset.y + layoutMeasurement.height)
       setAtBottom(distanceFromBottom < 80)
-      // Near the top — page in older history.
-      if (contentOffset.y < 60 && hasMore && !loadingEarlier) {
+      // Near the top — page in older history, but only if the user put us here.
+      if (userDraggingRef.current && contentOffset.y < 60 && hasMore && !loadingEarlier) {
         onLoadEarlier?.()
       }
     },
@@ -293,6 +297,24 @@ export function MobileNativeChatView({
               keyboardShouldPersistTaps="handled"
               onScroll={onScroll}
               scrollEventThrottle={32}
+              onScrollBeginDrag={() => {
+                userDraggingRef.current = true
+              }}
+              // Momentum outlives the finger, and a fling from mid-list is still
+              // the user asking for history — so the flag clears only once the
+              // list is fully at rest.
+              onMomentumScrollEnd={() => {
+                userDraggingRef.current = false
+              }}
+              onScrollEndDrag={(e) => {
+                if (e.nativeEvent.velocity == null || e.nativeEvent.velocity.y === 0) {
+                  userDraggingRef.current = false
+                }
+              }}
+              // Why: paging in history prepends up to PAGE rows above the
+              // viewport. Without an anchor the reader is pushed down by
+              // whatever those rows measure to.
+              maintainVisibleContentPosition={{ minIndexForVisible: 1 }}
               onContentSizeChange={() => {
                 if (data.length > 0 && atBottom) {
                   listRef.current?.scrollToEnd({ animated: false })

--- a/mobile/src/session/use-mobile-native-chat-scroll.ts
+++ b/mobile/src/session/use-mobile-native-chat-scroll.ts
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { FlatList, NativeScrollEvent, NativeSyntheticEvent } from 'react-native'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+
+/** Distance from the bottom, in px, still counted as "following the tail". */
+const AT_BOTTOM_SLACK = 80
+/** Offset under which a user-driven scroll asks for older history. */
+const LOAD_EARLIER_OFFSET = 60
+/** Let a growing list lay out before chasing its new bottom. */
+const TAIL_FOLLOW_DELAY_MS = 60
+
+type Args = {
+  messageCount: number
+  keyboardInset: number
+  hasMore?: boolean
+  loadingEarlier?: boolean
+  onLoadEarlier?: () => void
+}
+
+export type ChatScroll = {
+  listRef: React.RefObject<FlatList<NativeChatMessage> | null>
+  atBottom: boolean
+  /** Jump to the newest message and resume following the tail. */
+  jumpToLatest: () => void
+  /** Align one message's top with the top of the viewport. */
+  scrollToMessage: (index: number) => void
+  onScroll: (e: NativeSyntheticEvent<NativeScrollEvent>) => void
+  onScrollBeginDrag: () => void
+  onScrollEndDrag: (e: NativeSyntheticEvent<NativeScrollEvent>) => void
+  onMomentumScrollEnd: () => void
+  onContentSizeChange: () => void
+  onScrollToIndexFailed: (info: { index: number; averageItemLength: number }) => void
+}
+
+export function useMobileNativeChatScroll({
+  messageCount,
+  keyboardInset,
+  hasMore,
+  loadingEarlier,
+  onLoadEarlier
+}: Args): ChatScroll {
+  const listRef = useRef<FlatList<NativeChatMessage> | null>(null)
+  const [atBottom, setAtBottom] = useState(true)
+  // Why: onScroll cannot tell a programmatic scrollToEnd from a drag, and the
+  // one this view fires on open starts at offset 0 — its first throttled sample
+  // reads as "near the top" and pages in history nobody asked for.
+  const userDraggingRef = useRef(false)
+  const jumpTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(
+    () => () => {
+      if (jumpTimerRef.current) {
+        clearTimeout(jumpTimerRef.current)
+      }
+    },
+    []
+  )
+
+  // Follow the tail as the conversation grows and keep the newest message above
+  // the keyboard when it opens — but only when already pinned to the bottom, so
+  // we don't yank the user away while they read history. (Also fires on keyboard
+  // close, which is harmless while atBottom.)
+  useEffect(() => {
+    if (messageCount === 0 || !atBottom) {
+      return
+    }
+    const t = setTimeout(
+      () => listRef.current?.scrollToEnd({ animated: true }),
+      TAIL_FOLLOW_DELAY_MS
+    )
+    return () => clearTimeout(t)
+  }, [messageCount, atBottom, keyboardInset])
+
+  const jumpToLatest = useCallback(() => {
+    setAtBottom(true)
+    if (jumpTimerRef.current) {
+      clearTimeout(jumpTimerRef.current)
+    }
+    jumpTimerRef.current = setTimeout(() => {
+      jumpTimerRef.current = null
+      listRef.current?.scrollToEnd({ animated: true })
+    }, TAIL_FOLLOW_DELAY_MS)
+  }, [])
+
+  const scrollToMessage = useCallback((index: number) => {
+    listRef.current?.scrollToIndex({ index, viewPosition: 0, animated: true })
+  }, [])
+
+  const onScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent
+      const distanceFromBottom = contentSize.height - (contentOffset.y + layoutMeasurement.height)
+      setAtBottom(distanceFromBottom < AT_BOTTOM_SLACK)
+      // Near the top — page in older history, but only if the user put us here.
+      if (
+        userDraggingRef.current &&
+        contentOffset.y < LOAD_EARLIER_OFFSET &&
+        hasMore &&
+        !loadingEarlier
+      ) {
+        onLoadEarlier?.()
+      }
+    },
+    [hasMore, loadingEarlier, onLoadEarlier]
+  )
+
+  const onScrollBeginDrag = useCallback(() => {
+    userDraggingRef.current = true
+  }, [])
+
+  // Momentum outlives the finger, and a fling from mid-list is still the user
+  // asking for history — so the flag clears only once the list is at rest.
+  const onScrollEndDrag = useCallback((e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    if (e.nativeEvent.velocity == null || e.nativeEvent.velocity.y === 0) {
+      userDraggingRef.current = false
+    }
+  }, [])
+
+  const onMomentumScrollEnd = useCallback(() => {
+    userDraggingRef.current = false
+  }, [])
+
+  const onContentSizeChange = useCallback(() => {
+    if (messageCount > 0 && atBottom) {
+      listRef.current?.scrollToEnd({ animated: false })
+    }
+  }, [messageCount, atBottom])
+
+  // scrollToIndex can fail before an off-screen row is measured — fall back to
+  // an estimated offset, then retry once it's laid out.
+  const onScrollToIndexFailed = useCallback(
+    (info: { index: number; averageItemLength: number }) => {
+      listRef.current?.scrollToOffset({
+        offset: info.averageItemLength * info.index,
+        animated: true
+      })
+      setTimeout(() => {
+        listRef.current?.scrollToIndex({ index: info.index, viewPosition: 0, animated: true })
+      }, 120)
+    },
+    []
+  )
+
+  return {
+    listRef,
+    atBottom,
+    jumpToLatest,
+    scrollToMessage,
+    onScroll,
+    onScrollBeginDrag,
+    onScrollEndDrag,
+    onMomentumScrollEnd,
+    onContentSizeChange,
+    onScrollToIndexFailed
+  }
+}

--- a/tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts
+++ b/tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeAll, describe, expect, it } from 'vitest'
-import { resolveBaselineReleaseRef, selectLatestStableReleaseTag } from './release-checkout'
+import {
+  resolveBaselineReleaseRef,
+  selectBaselineReleaseTag,
+  selectLatestPrereleaseTag,
+  selectLatestStableReleaseTag
+} from './release-checkout'
 import {
   JOURNEY_INPUTS,
   JOURNEY_STEPS,
@@ -102,6 +107,35 @@ describe('cross-version remote terminal wire', () => {
         'v1.4.176'
       ])
     ).toBe('v1.4.176')
+  })
+
+  // This fork has published only release candidates, so a stable-only baseline
+  // leaves the lane with nothing to pair against.
+  it('falls back to the newest prerelease when no stable release exists', () => {
+    const tags = ['v799', 'mobile-v9.0.0', 'v1.4.189-rc.0', 'v1.4.189-rc.7', 'v1.4.189-rc.2']
+
+    expect(selectLatestStableReleaseTag(tags)).toBeNull()
+    expect(selectLatestPrereleaseTag(tags)).toBe('v1.4.189-rc.7')
+  })
+
+  // Sorting these as strings puts rc.9 above rc.10.
+  it('orders release candidates numerically', () => {
+    expect(selectLatestPrereleaseTag(['v1.4.189-rc.9', 'v1.4.189-rc.10'])).toBe('v1.4.189-rc.10')
+    expect(selectLatestPrereleaseTag(['v1.4.190-rc.1', 'v1.4.189-rc.9'])).toBe('v1.4.190-rc.1')
+  })
+
+  // A stable release, once cut, must win over any candidate.
+  it('prefers a stable release over a newer-looking candidate', () => {
+    expect(selectLatestStableReleaseTag(['v1.4.188', 'v1.4.189-rc.7'])).toBe('v1.4.188')
+  })
+
+  // What the lane actually resolves. CI sees only this fork's tags — all rc —
+  // while a local `git tag --list` also carries upstream's stable ones, so this
+  // is the only place the CI case can be pinned.
+  it('resolves a baseline from candidates alone, and prefers stable when present', () => {
+    expect(selectBaselineReleaseTag(['v1.4.189-rc.0', 'v1.4.189-rc.7'])).toBe('v1.4.189-rc.7')
+    expect(selectBaselineReleaseTag(['v1.4.188', 'v1.4.189-rc.7'])).toBe('v1.4.188')
+    expect(selectBaselineReleaseTag(['v799', 'mobile-v9.0.0'])).toBeNull()
   })
 
   it(

--- a/tests/e2e/cross-version-wire/release-checkout.ts
+++ b/tests/e2e/cross-version-wire/release-checkout.ts
@@ -22,6 +22,11 @@ const ARCHIVE_PATHS = ['src/main', 'src/shared', 'src/preload', 'src/renderer', 
 
 const BASELINE_REF_ENV = 'MANTA_CROSS_VERSION_BASELINE_REF'
 const STABLE_DESKTOP_RELEASE_TAG = /^v\d+\.\d+\.\d+$/
+// Why a prerelease may stand in: this fork has published only release
+// candidates, so requiring a stable tag leaves the lane with no baseline at all
+// — and a cross-version lane that runs nothing is what this harness exists to
+// prevent. An rc tag is a real shipped build, so it pairs just as honestly.
+const PRERELEASE_DESKTOP_RELEASE_TAG = /^v\d+\.\d+\.\d+-rc\.\d+$/
 
 export type ReleaseCheckout = {
   /** The ref as requested, e.g. `v1.4.169`. */
@@ -81,10 +86,10 @@ export function resolveBaselineReleaseRef(): string {
         `Run it inside a git checkout, or pin a ref with ${BASELINE_REF_ENV}.`
     )
   }
-  const latest = selectLatestStableReleaseTag(tags)
+  const latest = selectBaselineReleaseTag(tags)
   if (!latest) {
     throw new Error(
-      `Cross-version harness found no stable desktop release tags matching vX.Y.Z (saw ${tags.length} tag(s) total). ` +
+      `Cross-version harness found no desktop release tags matching vX.Y.Z or vX.Y.Z-rc.N (saw ${tags.length} tag(s) total). ` +
         'CI checkouts default to a shallow clone with no tags: use `actions/checkout` with `fetch-depth: 0`, ' +
         `or pin a ref with ${BASELINE_REF_ENV}.`
     )
@@ -99,6 +104,38 @@ export function selectLatestStableReleaseTag(tags: string[]): string | null {
       .sort(compareReleaseTags)
       .at(-1) ?? null
   )
+}
+
+/**
+ * The tag the lane pairs against: newest stable if this fork has cut one, else
+ * newest release candidate.
+ *
+ * Kept separate from {@link resolveBaselineReleaseRef} so the choice is testable
+ * without a git checkout — locally `git tag --list` also carries upstream's tags,
+ * which include stable releases this fork never published, so a test that shells
+ * out cannot see what CI sees.
+ */
+export function selectBaselineReleaseTag(tags: string[]): string | null {
+  return selectLatestStableReleaseTag(tags) ?? selectLatestPrereleaseTag(tags)
+}
+
+/** Newest `vX.Y.Z-rc.N`, used only when no stable release exists to pair against. */
+export function selectLatestPrereleaseTag(tags: string[]): string | null {
+  return (
+    tags
+      .filter((tag) => PRERELEASE_DESKTOP_RELEASE_TAG.test(tag))
+      .sort(comparePrereleaseTags)
+      .at(-1) ?? null
+  )
+}
+
+function comparePrereleaseTags(a: string, b: string): number {
+  const base = compareReleaseTags(a.replace(/-rc\.\d+$/, ''), b.replace(/-rc\.\d+$/, ''))
+  if (base !== 0) {
+    return base
+  }
+  const rc = (tag: string): number => Number.parseInt(/-rc\.(\d+)$/.exec(tag)?.[1] ?? '0', 10)
+  return rc(a) - rc(b)
 }
 
 function resolveCommit(ref: string): string {


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​139 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​136 |
| Prod | 13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​307 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​116 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​191 |

<!-- /manta-pr-loc -->

打开 Claude Code 会话时，聊天视图偶尔会自己定位到会话中间。

`onScroll` 是「是否在底部」和「加载更早」两件事唯一的判断来源，而它分不清程序化滚动和用户拖动。视图打开时会从 offset 0 发起 `scrollToEnd` 动画，那段动画的头几帧采样读作「靠近顶部」，于是自动触发了没人要的翻页——一次在视口上方前置 60 行（初始只有 40 行），列表又没有位置锚点，而 `scrollToEnd` 还在朝旧的内容高度滚。同一批中间帧已经把 `atBottom` 置成 false，于是 `onContentSizeChange` 的重新吸底和跟随末尾的 effect 双双停摆，人就停在旧底部所在的位置。

- 翻页只在用户真的在拖动或惯性滑动时触发
- 加 `maintainVisibleContentPosition`，前置插入不再顶走读者

第二个提交把同步流程改成走 PR。这个仓库**推 main 不触发任何 CI**——`pr.yml` 和 `mobile.yml` 都只认 `pull_request`，发布流水线只构建不跑测试。上一次同步的 380 个文件就是这样直接落到 main 的，其中 67 个在 `mobile/` 下，而唯一加载 Fastfile 的检查正是 `mobile.yml`。

这个 PR 顺带让上次同步第一次拿到 CI 覆盖。