### PR TITLE
fix(mobile): stop the home screen calling a built-in Hermes does not have

### DIFF
--- a/mobile/src/components/NewWorktreeModal.tsx
+++ b/mobile/src/components/NewWorktreeModal.tsx
@@ -90,7 +90,7 @@ function NewWorktreeModalContent(props: NewWorktreeModalProps) {
     detectedAgentIds: executionTarget.detectedAgentIds
   })
   const retiredNamesRefreshKey = useMemo(
-    () => (existingWorktreePaths ?? []).toSorted().join('\0'),
+    () => [...(existingWorktreePaths ?? [])].sort().join('\0'),
     [existingWorktreePaths]
   )
   const retiredWorktreeNames = useRetiredWorktreeNames(

--- a/mobile/src/hermes-builtin-support.test.ts
+++ b/mobile/src/hermes-builtin-support.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Built-ins Hermes does not ship must not reach mobile source.
+ *
+ * `hosts.toSorted(...)` passed typecheck, passed 3769 unit tests, and shipped —
+ * then crashed the app on launch with `undefined is not a function`, because the
+ * home screen's data hook evaluates it on first render. Nothing local can catch
+ * this: TypeScript's lib has the method, the tests run on Node, and the suite
+ * mocks react-native wholesale. React Native polyfills syntax, not built-ins.
+ *
+ * Every entry here is a method whose absence is a runtime TypeError rather than
+ * a build failure, so the copy-free spread form is the only safe spelling.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { extname, join, relative, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const MOBILE_ROOT = resolve(import.meta.dirname, '..')
+const ROOTS = [join(MOBILE_ROOT, 'src'), join(MOBILE_ROOT, 'app')]
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx'])
+
+/** Method name → the spelling to use instead. */
+const UNSUPPORTED: Record<string, string> = {
+  toSorted: '[...x].sort(…)',
+  toReversed: '[...x].reverse()',
+  toSpliced: '[...x].splice(…) on a copy',
+  groupBy: 'a plain reduce',
+  withResolvers: 'new Promise((resolve, reject) => …)'
+}
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry.startsWith('.')) {
+      continue
+    }
+    const path = join(dir, entry)
+    if (statSync(path).isDirectory()) {
+      out.push(...sourceFiles(path))
+    } else if (SOURCE_EXTENSIONS.has(extname(entry)) && !/\.(test|spec)\.tsx?$/.test(entry)) {
+      out.push(path)
+    }
+  }
+  return out
+}
+
+describe('Hermes built-in support', () => {
+  it('never calls a method Hermes may not have', () => {
+    const offenders: string[] = []
+    for (const root of ROOTS) {
+      for (const file of sourceFiles(root)) {
+        const source = readFileSync(file, 'utf8')
+        for (const [method, instead] of Object.entries(UNSUPPORTED)) {
+          const call = new RegExp(`\\.${method}\\s*\\(`)
+          if (call.test(source)) {
+            offenders.push(`${relative(MOBILE_ROOT, file)}: .${method}() — use ${instead}`)
+          }
+        }
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+})

--- a/mobile/src/home/use-mobile-home-data.ts
+++ b/mobile/src/home/use-mobile-home-data.ts
@@ -128,11 +128,11 @@ export function useMobileHomeData() {
   )
 
   const sortedHosts = useMemo(
-    () => hosts.toSorted((left, right) => right.lastConnected - left.lastConnected),
+    () => [...hosts].sort((left, right) => right.lastConnected - left.lastConnected),
     [hosts]
   )
   const sortedHostCatalog = useMemo(
-    () => hostCatalog.toSorted((left, right) => right.lastConnected - left.lastConnected),
+    () => [...hostCatalog].sort((left, right) => right.lastConnected - left.lastConnected),
     [hostCatalog]
   )
   const hostIds = useMemo(() => hosts.map((host) => host.id), [hosts])


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​62 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​62 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | 0 |

<!-- /manta-pr-loc -->

build 6 装上后启动即闪退。设备崩溃日志：

```
Unhandled JS Exception: TypeError: undefined is not a function
  at MobileHomeScreen
```

上游那次首页重构带进了 `hosts.toSorted(...)`，而首页的数据 hook 首次渲染就会求值。React Native 只为语法打 polyfill、不为内置方法打，Hermes 没有 `Array.prototype.toSorted`。

改成 `[...x].sort(...)` —— 两者都返回新数组，语义一致，也是这个仓库里既有的写法。

本地任何一道门禁都抓不到它：TypeScript 的 lib 里有这个方法、单测跑在 Node 上、而且整个 react-native 被 mock 掉了。所以补了一道读源码的门禁，顺带覆盖其余 change-by-copy 方法和 `Object.groupBy`、`Promise.withResolvers`。

崩溃报告里出错线程是 `com.meta.react.turbomodulemanager.queue`、`objc_exception_rethrow`，看着像原生问题——那只是 RCTFatal 把 JS 错误重新抛成 ObjC 异常的地方，不是故障点本身。