### PR TITLE
fix(mobile): stop every reply bouncing the chat reader up the transcript

### DIFF
--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -249,12 +249,9 @@ describe('MobileNativeChatView', () => {
       return renderer!.root.find((node) => node.type === 'FlatList')
     }
 
-    /** The jump-to-latest control; absent means the view is following the tail. */
-    function jumpToLatestButton(): ReactTestInstance | null {
-      return (
-        renderer!.root.findAll((node) => node.props.accessibilityLabel === 'Scroll to latest')[0] ??
-        null
-      )
+    /** The jump-to-latest control; empty means the view is following the tail. */
+    function jumpToLatestButtons(): ReactTestInstance[] {
+      return renderer!.root.findAll((node) => node.props.accessibilityLabel === 'Scroll to latest')
     }
 
     async function scrollTo(offsetY: number): Promise<void> {
@@ -329,7 +326,7 @@ describe('MobileNativeChatView', () => {
       // A mid-animation sample: still far from the bottom, no drag in progress.
       await scrollTo(0)
 
-      expect(jumpToLatestButton()).toBeNull()
+      expect(jumpToLatestButtons()).toHaveLength(0)
     })
 
     it('stops following once the user drags away from the bottom', async () => {
@@ -338,7 +335,7 @@ describe('MobileNativeChatView', () => {
       await act(async () => list().props.onScrollBeginDrag())
       await scrollTo(0)
 
-      expect(jumpToLatestButton()).not.toBeNull()
+      expect(jumpToLatestButtons()).toHaveLength(1)
     })
   })
 })

--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -249,6 +249,14 @@ describe('MobileNativeChatView', () => {
       return renderer!.root.find((node) => node.type === 'FlatList')
     }
 
+    /** The jump-to-latest control; absent means the view is following the tail. */
+    function jumpToLatestButton(): ReactTestInstance | null {
+      return (
+        renderer!.root.findAll((node) => node.props.accessibilityLabel === 'Scroll to latest')[0] ??
+        null
+      )
+    }
+
     async function scrollTo(offsetY: number): Promise<void> {
       await act(async () => {
         list().props.onScroll({
@@ -298,12 +306,39 @@ describe('MobileNativeChatView', () => {
       expect(onLoadEarlier).toHaveBeenCalledTimes(1)
     })
 
-    // A prepended page measures to whatever its rows render to, so without an
-    // anchor it pushes the reader down by that much.
-    it('anchors visible content so a prepend does not move the reader', async () => {
+    /**
+     * `maintainVisibleContentPosition` looked like the right way to stop a
+     * prepend moving the reader, and it fought the scrollToEnd this view fires
+     * on every new message: each reply bounced the reader up the transcript.
+     * Paging is guarded by the drag flag above, so the anchor is not needed.
+     */
+    it('does not anchor content position', async () => {
       await render({ messages: [assistantTurn('a', 'one')], hasMore: true })
 
-      expect(list().props.maintainVisibleContentPosition).toEqual({ minIndexForVisible: 1 })
+      expect(list().props.maintainVisibleContentPosition).toBeUndefined()
+    })
+
+    /**
+     * scrollToEnd emits samples on its way down. Reading those as "the user
+     * left the bottom" turns following off mid-flight, and then nothing re-pins
+     * — which is how the jump-to-latest button appeared on every reply.
+     */
+    it('keeps following the tail through its own scroll', async () => {
+      await render({ messages: [assistantTurn('a', 'one')] })
+
+      // A mid-animation sample: still far from the bottom, no drag in progress.
+      await scrollTo(0)
+
+      expect(jumpToLatestButton()).toBeNull()
+    })
+
+    it('stops following once the user drags away from the bottom', async () => {
+      await render({ messages: [assistantTurn('a', 'one')] })
+
+      await act(async () => list().props.onScrollBeginDrag())
+      await scrollTo(0)
+
+      expect(jumpToLatestButton()).not.toBeNull()
     })
   })
 })

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -249,10 +249,6 @@ export function MobileNativeChatView({
               onScrollBeginDrag={scroll.onScrollBeginDrag}
               onScrollEndDrag={scroll.onScrollEndDrag}
               onMomentumScrollEnd={scroll.onMomentumScrollEnd}
-              // Why: paging in history prepends rows above the viewport.
-              // Without an anchor the reader is pushed down by whatever those
-              // rows measure to.
-              maintainVisibleContentPosition={{ minIndexForVisible: 1 }}
               onContentSizeChange={scroll.onContentSizeChange}
               onScrollToIndexFailed={scroll.onScrollToIndexFailed}
               ListHeaderComponent={

--- a/mobile/src/session/use-mobile-native-chat-scroll.ts
+++ b/mobile/src/session/use-mobile-native-chat-scroll.ts
@@ -57,9 +57,9 @@ export function useMobileNativeChatScroll({
   )
 
   // Follow the tail as the conversation grows and keep the newest message above
-  // the keyboard when it opens — but only when already pinned to the bottom, so
-  // we don't yank the user away while they read history. (Also fires on keyboard
-  // close, which is harmless while atBottom.)
+  // the keyboard when it opens — but only while following, so we don't yank the
+  // user away while they read history. (Also fires on keyboard close, which is
+  // harmless while following.)
   useEffect(() => {
     if (messageCount === 0 || !atBottom) {
       return
@@ -83,21 +83,26 @@ export function useMobileNativeChatScroll({
   }, [])
 
   const scrollToMessage = useCallback((index: number) => {
+    // Jumping to a specific message is the user leaving the tail on purpose.
+    setAtBottom(false)
     listRef.current?.scrollToIndex({ index, viewPosition: 0, animated: true })
   }, [])
 
   const onScroll = useCallback(
     (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      // Why only while the user drives: following the tail is a mode, not a
+      // measurement. The scrollToEnd this hook fires itself emits samples on its
+      // way down, and reading those flips following off mid-flight — which is
+      // how every incoming reply started bouncing the reader up the transcript
+      // and revealing the jump-to-latest button.
+      if (!userDraggingRef.current) {
+        return
+      }
       const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent
       const distanceFromBottom = contentSize.height - (contentOffset.y + layoutMeasurement.height)
       setAtBottom(distanceFromBottom < AT_BOTTOM_SLACK)
       // Near the top — page in older history, but only if the user put us here.
-      if (
-        userDraggingRef.current &&
-        contentOffset.y < LOAD_EARLIER_OFFSET &&
-        hasMore &&
-        !loadingEarlier
-      ) {
+      if (contentOffset.y < LOAD_EARLIER_OFFSET && hasMore && !loadingEarlier) {
         onLoadEarlier?.()
       }
     },


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /manta-pr-loc -->

在底部发一条消息，Claude Code 回复后视图会跳到上面，右下角冒出「回到底部」按钮。每条新消息都会出现。

两个问题，都是我上一版改出来的：

1. **`maintainVisibleContentPosition` 和 `scrollToEnd` 打架**。它本来是为了让翻历史时前置插入不顶走读者，但追加消息的路径比翻历史频繁得多，两者一直互相纠正。翻页已经有拖动护栏兜着，这个锚点没有存在必要，去掉。

2. **「跟随末尾」是从滚动测量推导出来的，于是被自己的动画关掉了**。`scrollToEnd` 从上往下滚，途中的采样读作「离底部很远」，跟随标记就在动画飞行途中被清掉；之后 `onContentSizeChange` 拒绝重新吸底，按钮就冒出来了。所以是每条必现，而不是偶发。

现在跟随是**只有用户能改的模式**：往上拖离开、拖回底部或发消息或点按钮回到、点某条消息的「回到顶部」是主动离开。程序化滚动不再有发言权。

反向验证过：去掉护栏后 3 条断言变红，含新加的「程序化滚动不该中断跟随」。