### PR TITLE
fix(mobile): stop re-notifying everything a push already delivered

### DIFF
--- a/mobile/modules/push-delivered-seq/expo-module.config.json
+++ b/mobile/modules/push-delivered-seq/expo-module.config.json
@@ -1,0 +1,4 @@
+{
+  "platforms": ["ios"],
+  "ios": { "modules": ["PushDeliveredSeqModule"] }
+}

--- a/mobile/modules/push-delivered-seq/index.ts
+++ b/mobile/modules/push-delivered-seq/index.ts
@@ -21,7 +21,6 @@ type PushDeliveredSeq = {
 
 function native(): PushDeliveredSeq | null {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const core = require('expo-modules-core') as {
       requireOptionalNativeModule: <T>(name: string) => T | null
     }

--- a/mobile/modules/push-delivered-seq/index.ts
+++ b/mobile/modules/push-delivered-seq/index.ts
@@ -1,0 +1,47 @@
+/**
+ * How far a delivered push carried the desktop's notification counter.
+ *
+ * The catch-up watermark only advances on a live socket delivery, so everything
+ * APNs showed while the app was closed is still "missed" on the next open and
+ * gets notified again. The notification service extension records each push as
+ * it arrives; this reads that back so the catch-up can skip what the user has
+ * already seen.
+ *
+ * Optional on purpose: a build without the module — Android, a simulator, an
+ * older install — simply learns nothing, and the catch-up behaves as it did
+ * before, which over-notifies rather than under-notifies.
+ *
+ * Resolved lazily rather than at import time. expo-modules-core reaches
+ * react-native, whose Flow source the test runner cannot parse, so a top-level
+ * import would take every test that transitively touches notifications with it.
+ */
+type PushDeliveredSeq = {
+  seqForEpoch: (epoch: string) => number | null
+}
+
+function native(): PushDeliveredSeq | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const core = require('expo-modules-core') as {
+      requireOptionalNativeModule: <T>(name: string) => T | null
+    }
+    return core.requireOptionalNativeModule<PushDeliveredSeq>('PushDeliveredSeq')
+  } catch {
+    return null
+  }
+}
+
+/** Tells a missing native module apart from an epoch no push has covered. */
+export function isPushDeliveredSeqLinked(): boolean {
+  return native() !== null
+}
+
+export function readDeliveredSeq(epoch: string): number | null {
+  try {
+    return native()?.seqForEpoch(epoch) ?? null
+  } catch {
+    // A throw here would take the catch-up down with it, and the whole point of
+    // this value is to make the catch-up quieter, never to gate it.
+    return null
+  }
+}

--- a/mobile/modules/push-delivered-seq/ios/PushDeliveredSeq.podspec
+++ b/mobile/modules/push-delivered-seq/ios/PushDeliveredSeq.podspec
@@ -1,0 +1,28 @@
+# Without this file expo-modules-autolinking finds the module and then discards
+# it: resolveModuleAsync returns null when there is no podspec, so the module
+# never reaches the Podfile or ExpoModulesProvider. requireOptionalNativeModule
+# then returns null forever, the catch-up never learns what the extension
+# already delivered, and every push is notified a second time on the next open.
+Pod::Spec.new do |s|
+  s.name           = 'PushDeliveredSeq'
+  # Hardcoded: this module is local to the app and has no package.json to read.
+  s.version        = '1.0.0'
+  s.summary        = 'Reads how far a delivered push carried the notification counter'
+  s.description    = s.summary
+  s.license        = 'MIT'
+  s.author         = 'Manta'
+  s.homepage       = 'https://github.com/paidaxingyo666/Manta'
+  s.platforms      = { :ios => '15.1' }
+  s.swift_version  = '5.4'
+  s.source         = { git: 'https://github.com/paidaxingyo666/Manta.git' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+  }
+
+  s.source_files = "**/*.{h,m,swift}"
+end

--- a/mobile/modules/push-delivered-seq/ios/PushDeliveredSeqModule.swift
+++ b/mobile/modules/push-delivered-seq/ios/PushDeliveredSeqModule.swift
@@ -1,0 +1,36 @@
+import ExpoModulesCore
+
+/// Reads what the notification service extension recorded on each delivered push.
+///
+/// The app's catch-up watermark only advances when a notification arrives over a
+/// live socket. Everything APNs showed while the app was closed leaves it
+/// untouched, so the next connect asks the desktop for that whole span again and
+/// notifies all of it a second time. The extension writes how far each push
+/// carried the counter; this hands that back so the catch-up can skip it.
+///
+/// Read-only on purpose. The extension owns the writes — it is the only side
+/// that runs for every delivery — and a second writer could only walk the mark
+/// backwards.
+public class PushDeliveredSeqModule: Module {
+  private let appGroup = "group.cn.sh.manta.mobile"
+  private let deliveredKey = "pushDeliveredSeqByEpoch"
+
+  public func definition() -> ModuleDefinition {
+    Name("PushDeliveredSeq")
+
+    /// Highest sequence a push delivered for `epoch`, or nil if none did.
+    ///
+    /// Keyed by epoch because a sequence only means something inside one
+    /// counter lifetime: a desktop restart begins a new one, and folding a
+    /// number from the old counter into the new would skip real notifications.
+    Function("seqForEpoch") { (epoch: String) -> Int? in
+      guard
+        let defaults = UserDefaults(suiteName: appGroup),
+        let marks = defaults.dictionary(forKey: deliveredKey) as? [String: Int]
+      else {
+        return nil
+      }
+      return marks[epoch]
+    }
+  }
+}

--- a/mobile/plugins/notification-service/NotificationService.swift
+++ b/mobile/plugins/notification-service/NotificationService.swift
@@ -9,6 +9,13 @@ import Security
 /// exactly as it arrived. The generic text the desktop already put in `alert`
 /// is the floor, and showing that is always better than showing nothing.
 class NotificationService: UNNotificationServiceExtension {
+  /// Shared with the app: the keychain group holding the decryption key, and
+  /// the defaults suite holding how far each push carried the counter.
+  private static let appGroup = "group.cn.sh.manta.mobile"
+  /// Read by the app before it asks the desktop what it missed.
+  private static let deliveredKey = "pushDeliveredSeqByEpoch"
+  private static let maxTrackedEpochs = 8
+
   private var handler: ((UNNotificationContent) -> Void)?
   private var content: UNMutableNotificationContent?
 
@@ -22,6 +29,12 @@ class NotificationService: UNNotificationServiceExtension {
       contentHandler(request.content)
       return
     }
+
+    // Before every guard below: those all end in the desktop's generic text,
+    // which is still a delivered notification. Recording only on the decrypt
+    // path would leave the app re-notifying everything the extension could not
+    // read — the exact duplicate this mark exists to stop.
+    recordDelivered(request.content.userInfo)
 
     guard
       let sealed = request.content.userInfo["mb"] as? [String: Any],
@@ -96,6 +109,40 @@ class NotificationService: UNNotificationServiceExtension {
 
   // MARK: - Shared key
 
+  /// Records how far this push carried the desktop's notification counter.
+  ///
+  /// The app's catch-up watermark only advances on a live socket delivery, so
+  /// without this every push shown while the app was closed is replayed as a
+  /// local notification on the next open. Keyed by epoch because a seq means
+  /// nothing across a desktop restart.
+  ///
+  /// Best effort by design: a miss here costs a duplicate notification, and
+  /// nothing about it is worth failing a delivery over.
+  private func recordDelivered(_ userInfo: [AnyHashable: Any]) {
+    guard
+      let seq = userInfo["ds"] as? Int,
+      let epoch = userInfo["de"] as? String,
+      let defaults = UserDefaults(suiteName: Self.appGroup)
+    else {
+      return
+    }
+    var marks = defaults.dictionary(forKey: Self.deliveredKey) as? [String: Int] ?? [:]
+    // Monotonic: pushes can arrive out of order, and a lower seq must never
+    // walk the mark backwards into ground the app has already skipped.
+    if let known = marks[epoch], known >= seq {
+      return
+    }
+    marks[epoch] = seq
+    // One epoch per desktop counter lifetime, so this grows only with restarts
+    // of paired desktops. Keeping the newest few bounds it without needing to
+    // know which epoch is live — the app ignores every epoch but its own.
+    if marks.count > Self.maxTrackedEpochs {
+      let newest = marks.sorted { $0.value > $1.value }.prefix(Self.maxTrackedEpochs)
+      marks = Dictionary(uniqueKeysWithValues: newest.map { ($0.key, $0.value) })
+    }
+    defaults.set(marks, forKey: Self.deliveredKey)
+  }
+
   /// Reads the key the app published into the shared keychain group.
   ///
   /// The access group is what makes this readable from an extension at all: a
@@ -106,7 +153,7 @@ class NotificationService: UNNotificationServiceExtension {
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: "cn.sh.manta.mobile.push",
       kSecAttrAccount as String: "push-key",
-      kSecAttrAccessGroup as String: "group.cn.sh.manta.mobile",
+      kSecAttrAccessGroup as String: Self.appGroup,
       kSecReturnData as String: true,
       kSecMatchLimit as String: kSecMatchLimitOne
     ]

--- a/mobile/src/notifications/notification-reconnect-catchup.ts
+++ b/mobile/src/notifications/notification-reconnect-catchup.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
+import { readDeliveredSeq } from '../../modules/push-delivered-seq'
 
 // Why: the reconnect catch-up watermark + dedup helpers for #8129, extracted
 // from mobile-notifications.ts so that file stays under its max-lines budget.
@@ -319,6 +320,33 @@ export function adoptNotificationEpoch(
   session.catchUpQuarantineSeq = null
   session.lastDeliveredEpoch = epoch
   void saveWatermark(hostId, { seq: 0, epoch })
+
+  foldDeliveredPushes(session)
+}
+
+/**
+ * Skips what APNs already showed while the app was closed.
+ *
+ * The watermark advances only on a live socket delivery, so a push shown to a
+ * closed app leaves it where it was — and the next catch-up asks the desktop for
+ * that whole span again and notifies every bit of it a second time. The
+ * notification service extension records how far each push carried the counter;
+ * this folds that in once the session knows which counter it is on.
+ *
+ * In memory only. The persisted watermark is a promise that something was
+ * *shown*, and this reads back from a native module that may be absent or wrong;
+ * keeping it out of storage means a bad read costs one session rather than
+ * permanently skipping notifications nobody saw.
+ */
+function foldDeliveredPushes(session: HostNotificationSession): void {
+  const epoch = session.lastDeliveredEpoch
+  if (epoch === null) {
+    return
+  }
+  const delivered = readDeliveredSeq(epoch)
+  if (delivered != null && delivered > session.lastDeliveredSeq) {
+    session.lastDeliveredSeq = delivered
+  }
 }
 
 // Why: seed the watermark lazily so subscribe() doesn't block on an AsyncStorage read.
@@ -374,6 +402,7 @@ export function seedWatermarkFromStorage(session: HostNotificationSession, hostI
       if (session.lastDeliveredEpoch === null && epoch !== null) {
         session.lastDeliveredEpoch = epoch
       }
+      foldDeliveredPushes(session)
     }
   })
   // The late seed still applies when it eventually lands; the timeout only stops it

--- a/mobile/src/notifications/push-delivered-catchup.test.ts
+++ b/mobile/src/notifications/push-delivered-catchup.test.ts
@@ -1,0 +1,111 @@
+/**
+ * A push shown to a closed app must not be notified again on the next open.
+ *
+ * The catch-up watermark advances only when a notification arrives over a live
+ * socket, so everything APNs delivered while the app was closed left it where it
+ * was — and the next connect asked the desktop for that whole span again and
+ * re-notified all of it. The notification service extension records how far each
+ * push carried the counter; these pin that the session folds it in.
+ *
+ * Only the fold is testable here. Whether the extension actually wrote the value
+ * is a device question: it runs in its own process, only for a real delivery.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  adoptNotificationEpoch,
+  getHostNotificationSession,
+  resetHostNotificationSessionsForTests,
+  seedWatermarkFromStorage
+} from './notification-reconnect-catchup'
+import { readDeliveredSeq } from '../../modules/push-delivered-seq'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+vi.mock('../../modules/push-delivered-seq', () => ({
+  readDeliveredSeq: vi.fn(() => null)
+}))
+
+vi.mock('@react-native-async-storage/async-storage', () => {
+  const store = new Map<string, string>()
+  return {
+    default: {
+      getItem: vi.fn(async (key: string) => store.get(key) ?? null),
+      setItem: vi.fn(async (key: string, value: string) => void store.set(key, value)),
+      removeItem: vi.fn(async (key: string) => void store.delete(key)),
+      __store: store
+    }
+  }
+})
+
+const HOST = 'host-1'
+const EPOCH = 'epoch-a'
+
+function storeKey(hostId: string): string {
+  return `manta:mobileNotificationsWatermark:${hostId}`
+}
+
+describe('folding what a push already delivered', () => {
+  beforeEach(() => {
+    resetHostNotificationSessionsForTests()
+    ;(AsyncStorage as unknown as { __store: Map<string, string> }).__store.clear()
+    vi.mocked(readDeliveredSeq).mockReturnValue(null)
+  })
+
+  it('skips past a push the extension recorded for this counter', async () => {
+    vi.mocked(readDeliveredSeq).mockReturnValue(57)
+    const session = getHostNotificationSession(HOST)
+
+    adoptNotificationEpoch(session, HOST, EPOCH)
+
+    expect(readDeliveredSeq).toHaveBeenCalledWith(EPOCH)
+    expect(session.lastDeliveredSeq).toBe(57)
+  })
+
+  /**
+   * A sequence only means something inside one counter lifetime. Folding one
+   * from a dead counter would cut the new counter's own 1..N — the failure the
+   * epoch reset exists to prevent, reached through the push path instead.
+   */
+  it('ignores a mark recorded under a different counter', async () => {
+    vi.mocked(readDeliveredSeq).mockImplementation((epoch) => (epoch === 'epoch-old' ? 57 : null))
+    const session = getHostNotificationSession(HOST)
+
+    adoptNotificationEpoch(session, HOST, EPOCH)
+
+    expect(session.lastDeliveredSeq).toBe(0)
+  })
+
+  it('never walks the watermark backwards', async () => {
+    vi.mocked(readDeliveredSeq).mockReturnValue(3)
+    await AsyncStorage.setItem(storeKey(HOST), JSON.stringify({ seq: 40, epoch: EPOCH }))
+    const session = getHostNotificationSession(HOST)
+
+    seedWatermarkFromStorage(session, HOST)
+    await session.watermarkSeeded
+
+    expect(session.lastDeliveredSeq).toBe(40)
+  })
+
+  it('folds the mark in on the stored-watermark path too', async () => {
+    vi.mocked(readDeliveredSeq).mockReturnValue(88)
+    await AsyncStorage.setItem(storeKey(HOST), JSON.stringify({ seq: 40, epoch: EPOCH }))
+    const session = getHostNotificationSession(HOST)
+
+    seedWatermarkFromStorage(session, HOST)
+    await session.watermarkSeeded
+
+    expect(session.lastDeliveredSeq).toBe(88)
+  })
+
+  // A build without the module learns nothing and must behave exactly as before,
+  // which over-notifies rather than skipping something nobody saw.
+  it('leaves the watermark alone when the module is absent', async () => {
+    vi.mocked(readDeliveredSeq).mockReturnValue(null)
+    await AsyncStorage.setItem(storeKey(HOST), JSON.stringify({ seq: 40, epoch: EPOCH }))
+    const session = getHostNotificationSession(HOST)
+
+    seedWatermarkFromStorage(session, HOST)
+    await session.watermarkSeeded
+
+    expect(session.lastDeliveredSeq).toBe(40)
+  })
+})

--- a/src/main/runtime/mobile-push-escalation.test.ts
+++ b/src/main/runtime/mobile-push-escalation.test.ts
@@ -32,6 +32,16 @@ function harness(overrides: Partial<PushEscalationDeps> = {}) {
 const notification = (title: string) =>
   ({ type: 'notification', source: 'agent', title, body: '' }) as never
 
+const sequenced = (title: string, seq: number, epoch = 'epoch-a') =>
+  ({
+    type: 'notification',
+    source: 'agent',
+    title,
+    body: '',
+    notificationSeq: seq,
+    notificationEpoch: epoch
+  }) as never
+
 describe('MobilePushEscalation', () => {
   it('pushes when nothing is listening', async () => {
     const h = harness()
@@ -240,4 +250,35 @@ describe('MobilePushEscalation', () => {
 
     await expect(h.elapse()).resolves.not.toThrow()
   })
+  /**
+   * Without this the phone's catch-up watermark only advances on a live socket
+   * delivery, so everything a push showed to a closed app is still "missed" on
+   * the next open and gets notified a second time.
+   */
+  describe('the mark that lets the phone skip what this push delivered', () => {
+    it('carries the highest sequence in the batch, with its epoch', async () => {
+      const h = harness()
+      h.escalation.schedule(sequenced('one', 41))
+      h.escalation.schedule(sequenced('two', 57))
+      h.escalation.schedule(sequenced('three', 12))
+      await h.elapse()
+
+      const payload = h.wake.mock.calls[0][0].payload
+      expect(payload.ds).toBe(57)
+      expect(payload.de).toBe('epoch-a')
+    })
+
+    // A seq means nothing without the counter it belongs to, so an event that
+    // carries no epoch stays the phone's job to re-check rather than to skip.
+    it('omits the mark when the batch carries no epoch', async () => {
+      const h = harness()
+      h.escalation.schedule(notification('one'))
+      await h.elapse()
+
+      const payload = h.wake.mock.calls[0][0].payload
+      expect(payload.ds).toBeUndefined()
+      expect(payload.de).toBeUndefined()
+    })
+  })
+
 })

--- a/src/main/runtime/mobile-push-escalation.ts
+++ b/src/main/runtime/mobile-push-escalation.ts
@@ -97,7 +97,8 @@ export class MobilePushEscalation {
           deviceToken: target.deviceToken,
           payload: pushPayload(
             this.deps.text(batch.length),
-            sealedBody(target.encryptionKeyB64, batch)
+            sealedBody(target.encryptionKeyB64, batch),
+            deliveredMark(batch)
           )
           // No apns-collapse-id. A constant one made every push replace the last
           // in Notification Center, so the phone only ever showed the newest
@@ -125,7 +126,8 @@ export class MobilePushEscalation {
  */
 function pushPayload(
   text: { title: string; body: string },
-  sealed: EncryptedPushBody | null
+  sealed: EncryptedPushBody | null,
+  delivered: DeliveredMark | null
 ): Record<string, unknown> {
   return {
     aps: {
@@ -137,8 +139,40 @@ function pushPayload(
       // what replaces the text above with what actually happened.
       'mutable-content': 1
     },
-    ...(sealed ? { mb: sealed } : {})
+    ...(sealed ? { mb: sealed } : {}),
+    ...(delivered ? { ds: delivered.seq, de: delivered.epoch } : {})
   }
+}
+
+/**
+ * How far the phone's catch-up may skip once this push lands.
+ *
+ * Without it the watermark only ever advances on a live socket delivery, so
+ * everything APNs showed while the app was closed is still missed-since-last-
+ * connect on the next open and gets notified a second time. The extension
+ * records this on arrival; the app folds it in before asking what it missed.
+ *
+ * The epoch travels with it because a seq only means anything inside one
+ * counter lifetime — a desktop restart makes the number meaningless, and the
+ * phone must not fold a stale one into a fresh counter.
+ */
+type DeliveredMark = { seq: number; epoch: string }
+
+function deliveredMark(batch: readonly MobileNotificationEvent[]): DeliveredMark | null {
+  let seq: number | null = null
+  let epoch: string | null = null
+  for (const event of batch) {
+    if (event.type !== 'notification' || event.notificationSeq == null) {
+      continue
+    }
+    if (seq === null || event.notificationSeq > seq) {
+      seq = event.notificationSeq
+      epoch = event.notificationEpoch ?? null
+    }
+  }
+  // Why both: an event without an epoch predates the counter and cannot be
+  // folded in safely, so it stays the phone's job to re-check rather than skip.
+  return seq !== null && epoch !== null ? { seq, epoch } : null
 }
 
 /**


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​152 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​152 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​228 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​224 |

<!-- /manta-pr-loc -->

打开 app 后，之前已经推送过的通知会重新涌现一遍。

补发游标（watermark）只有一个推进点：通过实时连接收到事件并弹出本地通知之后。加了 APNs 推送以后这个等价关系就破了，而游标没跟上——后台期间推给用户的那些不动它，于是下次连接时补发把这整段又要了一遍。

改法：
- **桌面**：推送载荷带上这批里最大的序号和它的 epoch（`ds` / `de`）
- **扩展**：在自己所有 guard **之前**写进 App Group——解密失败也照样是送达了，只在解密成功时记录会把这类漏成重复通知
- **app**：session 知道自己在哪个 counter 上之后，把它折进游标

几个刻意的选择：

- **只存内存，不持久化**。持久化的游标是「这条已经给用户看过」的承诺，而这个值来自一个可能缺失或出错的原生模块。读错了只损失一个 session，而不是永久跳过没人看过的通知。
- **没有模块的构建什么都学不到**，行为和现在完全一致——宁可多弹也不少弹。
- **epoch 必须同行**。序号只在一个 counter 生命周期内有意义，把死掉 counter 的数字折进新的会砍掉新 counter 自己的 1..N，那正是 epoch 重置本来要防的事。

顺带：这是扩展第一次有可观测的输出。此前它做的任何事从 app 侧都看不见，这也是它每次失败都静默的原因。

自动化只能验到「折入」这一段——扩展是否真的写了值是真机问题，它在独立进程里、只在真实送达时运行。