### PR TITLE
fix(mobile): pin the chat bottom from the measured height, not cached metrics

### DIFF
--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -1,6 +1,6 @@
 import { createElement } from 'react'
 import { act, create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import { MobileNativeChatView } from './MobileNativeChatView'
 
@@ -103,9 +103,15 @@ describe('MobileNativeChatView', () => {
     renderer = null
   })
 
+  /** Stands in for the FlatList the view holds a ref to, so scrolls are visible. */
+  let listMock: { scrollToOffset: Mock; scrollToEnd: Mock; scrollToIndex: Mock }
+
   async function render(overrides: Overrides = {}): Promise<void> {
+    listMock = { scrollToOffset: vi.fn(), scrollToEnd: vi.fn(), scrollToIndex: vi.fn() }
     await act(async () => {
-      renderer = create(chatViewElement(overrides))
+      renderer = create(chatViewElement(overrides), {
+        createNodeMock: (element) => (element.type === 'FlatList' ? listMock : null)
+      })
     })
   }
 
@@ -274,7 +280,7 @@ describe('MobileNativeChatView', () => {
      */
     it('does not page in history for a scroll the user did not start', async () => {
       const onLoadEarlier = vi.fn()
-      await render({ messages: [assistantTurn('a', 'one')], hasMore: true, onLoadEarlier })
+      await render({ folded: [assistantTurn('a', 'one')], hasMore: true, onLoadEarlier })
 
       await scrollTo(10)
 
@@ -283,7 +289,7 @@ describe('MobileNativeChatView', () => {
 
     it('pages in history once the user drags to the top', async () => {
       const onLoadEarlier = vi.fn()
-      await render({ messages: [assistantTurn('a', 'one')], hasMore: true, onLoadEarlier })
+      await render({ folded: [assistantTurn('a', 'one')], hasMore: true, onLoadEarlier })
 
       await act(async () => list().props.onScrollBeginDrag())
       await scrollTo(10)
@@ -293,7 +299,7 @@ describe('MobileNativeChatView', () => {
 
     it('stops paging again once the list comes to rest', async () => {
       const onLoadEarlier = vi.fn()
-      await render({ messages: [assistantTurn('a', 'one')], hasMore: true, onLoadEarlier })
+      await render({ folded: [assistantTurn('a', 'one')], hasMore: true, onLoadEarlier })
 
       await act(async () => list().props.onScrollBeginDrag())
       await scrollTo(10)
@@ -310,7 +316,7 @@ describe('MobileNativeChatView', () => {
      * Paging is guarded by the drag flag above, so the anchor is not needed.
      */
     it('does not anchor content position', async () => {
-      await render({ messages: [assistantTurn('a', 'one')], hasMore: true })
+      await render({ folded: [assistantTurn('a', 'one')], hasMore: true })
 
       expect(list().props.maintainVisibleContentPosition).toBeUndefined()
     })
@@ -321,7 +327,7 @@ describe('MobileNativeChatView', () => {
      * — which is how the jump-to-latest button appeared on every reply.
      */
     it('keeps following the tail through its own scroll', async () => {
-      await render({ messages: [assistantTurn('a', 'one')] })
+      await render({ folded: [assistantTurn('a', 'one')] })
 
       // A mid-animation sample: still far from the bottom, no drag in progress.
       await scrollTo(0)
@@ -329,8 +335,23 @@ describe('MobileNativeChatView', () => {
       expect(jumpToLatestButtons()).toHaveLength(0)
     })
 
+    /**
+     * scrollToEnd reads the list's cached scroll metrics, and a streaming reply
+     * changes height faster than those refresh — so the pin kept landing at a
+     * bottom that had already moved, and the reader drifted up mid-answer.
+     */
+    it('re-pins from the measured height, not the list cached metrics', async () => {
+      await render({ folded: [assistantTurn('a', 'one')] })
+
+      await act(async () => list().props.onLayout({ nativeEvent: { layout: { height: 800 } } }))
+      await act(async () => list().props.onContentSizeChange(400, 3000))
+
+      expect(listMock.scrollToEnd).not.toHaveBeenCalled()
+      expect(listMock.scrollToOffset).toHaveBeenCalledWith({ offset: 2200, animated: false })
+    })
+
     it('stops following once the user drags away from the bottom', async () => {
-      await render({ messages: [assistantTurn('a', 'one')] })
+      await render({ folded: [assistantTurn('a', 'one')] })
 
       await act(async () => list().props.onScrollBeginDrag())
       await scrollTo(0)

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -250,6 +250,7 @@ export function MobileNativeChatView({
               onScrollEndDrag={scroll.onScrollEndDrag}
               onMomentumScrollEnd={scroll.onMomentumScrollEnd}
               onContentSizeChange={scroll.onContentSizeChange}
+              onLayout={scroll.onLayout}
               onScrollToIndexFailed={scroll.onScrollToIndexFailed}
               ListHeaderComponent={
                 hasMore ? (

--- a/mobile/src/session/use-mobile-native-chat-scroll.ts
+++ b/mobile/src/session/use-mobile-native-chat-scroll.ts
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import type { FlatList, NativeScrollEvent, NativeSyntheticEvent } from 'react-native'
+import type {
+  FlatList,
+  LayoutChangeEvent,
+  NativeScrollEvent,
+  NativeSyntheticEvent
+} from 'react-native'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 
 /** Distance from the bottom, in px, still counted as "following the tail". */
@@ -28,7 +33,8 @@ export type ChatScroll = {
   onScrollBeginDrag: () => void
   onScrollEndDrag: (e: NativeSyntheticEvent<NativeScrollEvent>) => void
   onMomentumScrollEnd: () => void
-  onContentSizeChange: () => void
+  onContentSizeChange: (width: number, height: number) => void
+  onLayout: (event: LayoutChangeEvent) => void
   onScrollToIndexFailed: (info: { index: number; averageItemLength: number }) => void
 }
 
@@ -45,6 +51,7 @@ export function useMobileNativeChatScroll({
   // one this view fires on open starts at offset 0 — its first throttled sample
   // reads as "near the top" and pages in history nobody asked for.
   const userDraggingRef = useRef(false)
+  const viewportHeightRef = useRef(0)
   const jumpTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(
@@ -125,11 +132,33 @@ export function useMobileNativeChatScroll({
     userDraggingRef.current = false
   }, [])
 
-  const onContentSizeChange = useCallback(() => {
-    if (messageCount > 0 && atBottom) {
-      listRef.current?.scrollToEnd({ animated: false })
-    }
-  }, [messageCount, atBottom])
+  /**
+   * Re-pins the bottom as content grows, using the height the callback reports.
+   *
+   * Not scrollToEnd: that reads the list's own cached scroll metrics, which lag
+   * a growing row. A streaming reply changes height far faster than those
+   * refresh, so the pin repeatedly landed at a bottom that had already moved —
+   * the reader drifted up mid-answer and only caught up when the finished
+   * message changed the row count and woke the effect above. The height handed
+   * in here is measured, not remembered.
+   */
+  const onContentSizeChange = useCallback(
+    (_width: number, height: number) => {
+      if (messageCount === 0 || !atBottom) {
+        return
+      }
+      listRef.current?.scrollToOffset({
+        offset: Math.max(0, height - viewportHeightRef.current),
+        animated: false
+      })
+    },
+    [messageCount, atBottom]
+  )
+
+  /** The viewport height the offset above subtracts; 0 until the first layout. */
+  const onLayout = useCallback((event: LayoutChangeEvent) => {
+    viewportHeightRef.current = event.nativeEvent.layout.height
+  }, [])
 
   // scrollToIndex can fail before an off-screen row is measured — fall back to
   // an estimated offset, then retry once it's laid out.
@@ -156,6 +185,7 @@ export function useMobileNativeChatScroll({
     onScrollEndDrag,
     onMomentumScrollEnd,
     onContentSizeChange,
+    onLayout,
     onScrollToIndexFailed
   }
 }


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 |

<!-- /manta-pr-loc -->

流式输出中途偶尔跟不住底部，输出完整后会回到底部。

补位用的是 `scrollToEnd`，它读的是列表自己缓存的滚动度量。流式回复的高度变化比这份缓存刷新得快，所以每次补位都落在一个**已经移动过的**底部上——读者在回答中途往上漂，直到消息输出完、行数变化唤醒跟随末尾的 effect 才被拉回。

`onContentSizeChange` 本来就把新的内容高度交到手上。减去 layout 时记下的视口高度，得到的偏移是**实测的**，不是记忆的。

另外修一个我自己的测试缺陷：上一版新加的测试传的是 `messages`，而列表渲染的是 `folded`——它们是在**空列表**上做断言。已改正，并把两处护栏都重新做了反向验证（拿掉后分别红 3 条和 1 条）。

自动化能验到的仍然只是「传给 FlatList 的参数和回调逻辑」；真机上的动画时序验不了，这条还得在设备上确认。