### PR TITLE
fix: follow a rolled transcript, and show the newest push

### DIFF
--- a/mobile/plugins/notification-service/NotificationService.swift
+++ b/mobile/plugins/notification-service/NotificationService.swift
@@ -43,7 +43,10 @@ class NotificationService: UNNotificationServiceExtension {
       let key = readSharedKey(),
       let plaintext = open(payload: payload, with: key),
       let items = decodeItems(plaintext),
-      let first = items.first
+      // Last, not first: the batch arrives oldest-first, and a lock screen has
+      // room for one line. Showing the oldest meant every push in a busy session
+      // displayed the same stale message no matter what had just happened.
+      let latest = items.last
     else {
       // Every one of these is the same outcome: the desktop's generic text.
       contentHandler(content)
@@ -53,8 +56,8 @@ class NotificationService: UNNotificationServiceExtension {
     // Both fall back to what the desktop already wrote. A decrypted-but-empty
     // body would otherwise replace readable generic text with nothing, which is
     // worse on the lock screen than not decrypting at all.
-    content.title = first.title.isEmpty ? content.title : first.title
-    let body = first.body.isEmpty ? content.body : first.body
+    content.title = latest.title.isEmpty ? content.title : latest.title
+    let body = latest.body.isEmpty ? content.body : latest.body
     content.body = items.count == 1 ? body : "\(body)\n+\(items.count - 1)"
     contentHandler(content)
   }

--- a/src/main/native-chat/claude-transcript-successor.test.ts
+++ b/src/main/native-chat/claude-transcript-successor.test.ts
@@ -1,0 +1,147 @@
+/**
+ * A compacted Claude session continues in a NEW file under a NEW id, and
+ * nothing in the old file says so — it simply stops. The session id the watcher
+ * holds still resolves to it, because that file is exactly `<old-id>.jsonl` and
+ * still exists, so the resolver's own "stale paths fall through" never fires.
+ *
+ * Shapes here are taken from a real roll: `sessionId` (camelCase) is the file's
+ * own session; `session_id` (snake_case) rides inside replayed rows and still
+ * names the session they were written under.
+ */
+import { describe, expect, it } from 'vitest'
+import { findSuccessorTranscript } from './claude-transcript-successor'
+
+const OLD = 'd7088df0-6130-486e-955a-eb08b295acce'
+const NEW = '051ba680-d60e-42e8-b69d-cd73abd31eac'
+const BOUND = `/p/${OLD}.jsonl`
+
+function rows(own: string, replayed: string[]): string {
+  return [
+    JSON.stringify({ type: 'ai-title', sessionId: own }),
+    ...replayed.map((id) => JSON.stringify({ type: 'user', sessionId: own, session_id: id })),
+    JSON.stringify({ type: 'assistant', sessionId: own })
+  ].join('\n')
+}
+
+type World = { names: string[]; mtimes: Record<string, number>; heads: Record<string, string> }
+
+function find(world: World, sessionId = OLD) {
+  return findSuccessorTranscript({
+    boundPath: BOUND,
+    sessionId,
+    readDirectory: async () => world.names,
+    mtimeMs: async (path) => {
+      const at = world.mtimes[path]
+      if (at === undefined) {
+        throw new Error(`ENOENT ${path}`)
+      }
+      return at
+    },
+    readLines: async function* (path) {
+      yield* (world.heads[path] ?? '').split('\n')
+    }
+  })
+}
+
+describe('findSuccessorTranscript', () => {
+  it('follows a roll to the file that replays our rows', async () => {
+    await expect(
+      find({
+        names: [`${OLD}.jsonl`, `${NEW}.jsonl`],
+        mtimes: { [BOUND]: 100, [`/p/${NEW}.jsonl`]: 200 },
+        heads: { [`/p/${NEW}.jsonl`]: rows(NEW, [OLD]) }
+      })
+    ).resolves.toEqual({ path: `/p/${NEW}.jsonl`, sessionId: NEW })
+  })
+
+  /**
+   * The whole point of the descent check. An idle session is quiet for hours and
+   * its neighbours are other conversations that happen to be newer — rebinding
+   * to one would move the user's chat to a stranger's transcript.
+   */
+  it('ignores a newer file that is a different conversation', async () => {
+    await expect(
+      find({
+        names: [`${OLD}.jsonl`, 'stranger.jsonl'],
+        mtimes: { [BOUND]: 100, '/p/stranger.jsonl': 900 },
+        heads: { '/p/stranger.jsonl': rows('stranger', ['someone-else']) }
+      })
+    ).resolves.toBeNull()
+  })
+
+  // A file older than the bound one cannot be where the session went next.
+  it('never rebinds backwards to an ancestor', async () => {
+    await expect(
+      find({
+        names: [`${OLD}.jsonl`, 'ancestor.jsonl'],
+        mtimes: { [BOUND]: 100, '/p/ancestor.jsonl': 50 },
+        heads: { '/p/ancestor.jsonl': rows('ancestor', [OLD]) }
+      })
+    ).resolves.toBeNull()
+  })
+
+  /**
+   * Only the DIRECT ancestor is replayed near the top; a grandparent lands
+   * thousands of lines in. Returning the owner id is what lets the caller
+   * re-search under it, so a chain is walked one link at a time.
+   */
+  it('reports the id the session continued under', async () => {
+    const result = await find({
+      names: [`${OLD}.jsonl`, `${NEW}.jsonl`],
+      mtimes: { [BOUND]: 100, [`/p/${NEW}.jsonl`]: 200 },
+      heads: { [`/p/${NEW}.jsonl`]: rows(NEW, [OLD]) }
+    })
+    expect(result?.sessionId).toBe(NEW)
+  })
+
+  /**
+   * A subagent writes its own file under the SAME session id. It is not where
+   * the conversation continued, and reporting it would rebind chat to a
+   * subagent's transcript while keeping the dead id — so the next roll could
+   * never be found either.
+   */
+  it('does not mistake a same-session sidecar for a successor', async () => {
+    await expect(
+      find({
+        names: [`${OLD}.jsonl`, 'sidecar.jsonl'],
+        mtimes: { [BOUND]: 100, '/p/sidecar.jsonl': 200 },
+        heads: { '/p/sidecar.jsonl': rows(OLD, [OLD]) }
+      })
+    ).resolves.toBeNull()
+  })
+
+  it('prefers the newest descendant when several rolls exist', async () => {
+    await expect(
+      find({
+        names: [`${OLD}.jsonl`, 'mid.jsonl', 'newest.jsonl'],
+        mtimes: { [BOUND]: 100, '/p/mid.jsonl': 200, '/p/newest.jsonl': 300 },
+        heads: {
+          '/p/mid.jsonl': rows('mid', [OLD]),
+          '/p/newest.jsonl': rows('newest', [OLD])
+        }
+      })
+    ).resolves.toEqual({ path: '/p/newest.jsonl', sessionId: 'newest' })
+  })
+
+  // The head is cut mid-file, so the last line is routinely half a row.
+  it('reads past a truncated final line', async () => {
+    await expect(
+      find({
+        names: [`${OLD}.jsonl`, `${NEW}.jsonl`],
+        mtimes: { [BOUND]: 100, [`/p/${NEW}.jsonl`]: 200 },
+        heads: { [`/p/${NEW}.jsonl`]: `${rows(NEW, [OLD])}\n{"type":"assist` }
+      })
+    ).resolves.toEqual({ path: `/p/${NEW}.jsonl`, sessionId: NEW })
+  })
+
+  // A sibling that vanished between readdir and stat is not a failure.
+  it('skips a candidate that disappeared mid-scan', async () => {
+    await expect(
+      find({
+        names: [`${OLD}.jsonl`, 'gone.jsonl', `${NEW}.jsonl`],
+        mtimes: { [BOUND]: 100, [`/p/${NEW}.jsonl`]: 200 },
+        heads: { [`/p/${NEW}.jsonl`]: rows(NEW, [OLD]) }
+      })
+    ).resolves.toEqual({ path: `/p/${NEW}.jsonl`, sessionId: NEW })
+  })
+})

--- a/src/main/native-chat/claude-transcript-successor.ts
+++ b/src/main/native-chat/claude-transcript-successor.ts
@@ -1,0 +1,174 @@
+import { createReadStream } from 'node:fs'
+import { readdir, stat } from 'node:fs/promises'
+import { createInterface } from 'node:readline'
+import { dirname, extname, join } from 'node:path'
+
+/**
+ * How many of a candidate's leading lines to examine.
+ *
+ * A compaction replays the prior conversation into the new file, and the
+ * immediate ancestor is named by the `isCompactSummary` row near the top — line
+ * 47 in the session that prompted this. Grandparents appear thousands of lines
+ * in, which is fine: this only ever needs the DIRECT child, and the watch
+ * re-arms after each hop, so a chain of rolls is walked one link at a time.
+ *
+ * Counted in lines, not bytes: those 47 lines are 540KB because
+ * `file-history-snapshot` rows run 12KB each, so any byte budget tight enough to
+ * be cheap on a stranger cuts the answer off on a real descendant. The scan
+ * streams and stops the moment it knows, so the common case reads far less.
+ */
+const HEAD_LINES = 400
+
+/**
+ * Where a rolled session continued, and under which id.
+ *
+ * The id matters as much as the path: only the DIRECT ancestor is replayed near
+ * enough to the top to be found in a bounded head read, so following a chain of
+ * rolls means re-searching under each new id in turn.
+ */
+export type TranscriptSuccessor = { path: string; sessionId: string }
+
+type Args = {
+  /** The transcript the watcher is bound to. */
+  boundPath: string
+  /** The session id that file belongs to. */
+  sessionId: string
+  signal?: AbortSignal
+  readDirectory?: (dirPath: string) => Promise<string[]>
+  readLines?: (path: string) => AsyncIterable<string>
+  mtimeMs?: (path: string) => Promise<number>
+}
+
+async function defaultReadDirectory(dirPath: string): Promise<string[]> {
+  return (await readdir(dirPath, { withFileTypes: true }))
+    .filter((entry) => entry.isFile() && extname(entry.name) === '.jsonl')
+    .map((entry) => entry.name)
+}
+
+function defaultReadLines(path: string): AsyncIterable<string> {
+  // Closing the reader early (a `break` in the consumer) destroys the stream, so
+  // a decided candidate stops costing I/O immediately.
+  return createInterface({ input: createReadStream(path), crlfDelay: Infinity })
+}
+
+async function defaultMtimeMs(path: string): Promise<number> {
+  return (await stat(path)).mtimeMs
+}
+
+/**
+ * Does this file's head claim `sessionId` as an ancestor?
+ *
+ * The discriminator is the two spellings Claude writes side by side: `sessionId`
+ * (camelCase) is the file's OWN session and is uniform throughout, while
+ * `session_id` (snake_case) rides along inside replayed rows and still names the
+ * session they were originally written under. So a row carrying
+ * `session_id === ours` in a file whose own `sessionId` differs is a positive
+ * statement of descent — not a heuristic about timing or names.
+ */
+async function ownSessionIfDescendedFrom(
+  lines: AsyncIterable<string>,
+  sessionId: string,
+  signal?: AbortSignal
+): Promise<string | null> {
+  let owner: string | null = null
+  let claimsDescent = false
+  let seen = 0
+  for await (const line of lines) {
+    signal?.throwIfAborted()
+    if (++seen > HEAD_LINES) {
+      return null
+    }
+    if (!line.startsWith('{')) {
+      continue
+    }
+    // These carry neither id and are 12KB apiece — most of what a scan walks.
+    if (line.includes('"type":"file-history-snapshot"')) {
+      continue
+    }
+    let row: Record<string, unknown>
+    try {
+      row = JSON.parse(line) as Record<string, unknown>
+    } catch {
+      continue
+    }
+    if (owner === null && typeof row.sessionId === 'string' && row.sessionId !== sessionId) {
+      owner = row.sessionId
+    }
+    if (row.session_id === sessionId) {
+      claimsDescent = true
+    }
+    if (owner !== null && claimsDescent) {
+      return owner
+    }
+  }
+  return null
+}
+
+/**
+ * Finds the file a rolled Claude session continued into, or null.
+ *
+ * Compaction does not append: it opens a NEW transcript under a NEW session id
+ * and replays the conversation into it. Nothing in the old file says so — it
+ * simply stops — and the session id the watcher holds still resolves to it,
+ * because that file is exactly `<old-id>.jsonl` and still exists. That is why
+ * the resolver's "stale paths fall through to the id-based search" never fired
+ * here, and why a watcher can sit healthy on a dead file for hours reporting
+ * `watching: true` with nothing to deliver.
+ *
+ * Only files newer than the bound one are considered, so an idle session (whose
+ * successors do not exist) costs one readdir and nothing else.
+ */
+export async function findSuccessorTranscript(args: Args): Promise<TranscriptSuccessor | null> {
+  const {
+    boundPath,
+    sessionId,
+    signal,
+    readDirectory = defaultReadDirectory,
+    readLines = defaultReadLines,
+    mtimeMs = defaultMtimeMs
+  } = args
+  signal?.throwIfAborted()
+
+  const dir = dirname(boundPath)
+  const boundMtime = await mtimeMs(boundPath)
+  const names = await readDirectory(dir)
+
+  const candidates: { path: string; mtime: number }[] = []
+  for (const name of names) {
+    signal?.throwIfAborted()
+    const path = join(dir, name)
+    if (path === boundPath) {
+      continue
+    }
+    let mtime: number
+    try {
+      mtime = await mtimeMs(path)
+    } catch {
+      continue
+    }
+    if (mtime > boundMtime) {
+      candidates.push({ path, mtime })
+    }
+  }
+
+  // Newest first: the end of a roll chain is the file actually being written.
+  candidates.sort((a, b) => b.mtime - a.mtime)
+  for (const candidate of candidates) {
+    signal?.throwIfAborted()
+    let owner: string | null
+    try {
+      owner = await ownSessionIfDescendedFrom(readLines(candidate.path), sessionId, signal)
+    } catch (error) {
+      signal?.throwIfAborted()
+      // A sibling that vanished or refused mid-scan is not a verdict.
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw error
+      }
+      continue
+    }
+    if (owner) {
+      return { path: candidate.path, sessionId: owner }
+    }
+  }
+  return null
+}

--- a/src/main/native-chat/transcript-rebind-watch.test.ts
+++ b/src/main/native-chat/transcript-rebind-watch.test.ts
@@ -1,0 +1,146 @@
+/**
+ * A watcher binds once and holds that descriptor. When the file stops being the
+ * one the agent writes, the watcher stays healthy and reports `watching: true`
+ * with nothing to deliver — indistinguishable from an idle conversation. One
+ * such bind sat unnoticed for seven hours.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { watchForTranscriptRebind } from './transcript-rebind-watch'
+
+const BOUND = '/p/old.jsonl'
+const SUCCESSOR = { path: '/p/new.jsonl', sessionId: 'new-id' }
+
+type Harness = {
+  fire: () => Promise<void>
+  onMoved: ReturnType<typeof vi.fn>
+  findSuccessor: ReturnType<typeof vi.fn>
+  stop: () => void
+}
+
+function harness(opts: { quietFor: number; successor?: typeof SUCCESSOR | null }): Harness {
+  const pending: (() => void)[] = []
+  const onMoved = vi.fn()
+  const findSuccessor = vi.fn(async () => opts.successor ?? null)
+  const watch = watchForTranscriptRebind({
+    agent: 'claude',
+    sessionId: 'old-id',
+    boundPath: BOUND,
+    onMoved,
+    intervalMs: 1,
+    quietBeforeSearchMs: 100,
+    now: () => 1_000_000,
+    mtimeMs: async () => 1_000_000 - opts.quietFor,
+    findSuccessor: findSuccessor as never,
+    setTimer: ((fn: () => void) => {
+      pending.push(fn)
+      return pending.length as never
+    }) as never,
+    clearTimer: (() => {}) as never
+  })
+  return {
+    fire: async () => {
+      const next = pending.shift()
+      next?.()
+      await vi.waitFor(() =>
+        expect(findSuccessor.mock.calls.length + onMoved.mock.calls.length >= 0).toBe(true)
+      )
+      await new Promise((r) => setTimeout(r, 0))
+    },
+    onMoved,
+    findSuccessor,
+    stop: watch.stop
+  }
+}
+
+describe('watchForTranscriptRebind', () => {
+  it('rebinds to where a rolled session continued', async () => {
+    const h = harness({ quietFor: 5_000, successor: SUCCESSOR })
+    await h.fire()
+    expect(h.onMoved).toHaveBeenCalledWith(SUCCESSOR)
+    h.stop()
+  })
+
+  /**
+   * The trigger is descent, never silence. An idle session must be left alone —
+   * this is the check that stops the fix from yanking a reader out of a
+   * conversation that was merely waiting on them.
+   */
+  it('leaves a quiet session with no successor alone', async () => {
+    const h = harness({ quietFor: 5_000, successor: null })
+    await h.fire()
+    expect(h.onMoved).not.toHaveBeenCalled()
+    h.stop()
+  })
+
+  // A live file is being written; searching its siblings is pure cost.
+  it('does not even search while the bound file is being written', async () => {
+    const h = harness({ quietFor: 1, successor: SUCCESSOR })
+    await h.fire()
+    expect(h.findSuccessor).not.toHaveBeenCalled()
+    expect(h.onMoved).not.toHaveBeenCalled()
+    h.stop()
+  })
+
+  // Only Claude rolls a session into a new file; the others keep appending.
+  it('never searches for a non-Claude agent', async () => {
+    const findSuccessor = vi.fn()
+    const onMoved = vi.fn()
+    const pending: (() => void)[] = []
+    watchForTranscriptRebind({
+      agent: 'codex',
+      sessionId: 'old-id',
+      boundPath: BOUND,
+      onMoved,
+      intervalMs: 1,
+      quietBeforeSearchMs: 100,
+      now: () => 1_000_000,
+      mtimeMs: async () => 0,
+      findSuccessor: findSuccessor as never,
+      setTimer: ((fn: () => void) => {
+        pending.push(fn)
+        return pending.length as never
+      }) as never,
+      clearTimer: (() => {}) as never
+    })
+    pending.shift()?.()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(findSuccessor).not.toHaveBeenCalled()
+    expect(onMoved).not.toHaveBeenCalled()
+  })
+
+  // Dropping a live binding because one probe raced a rename would turn a
+  // transient into an outage.
+  it('keeps the current binding when the probe throws', async () => {
+    const onMoved = vi.fn()
+    const pending: (() => void)[] = []
+    watchForTranscriptRebind({
+      agent: 'claude',
+      sessionId: 'old-id',
+      boundPath: BOUND,
+      onMoved,
+      intervalMs: 1,
+      quietBeforeSearchMs: 100,
+      now: () => 1_000_000,
+      mtimeMs: async () => {
+        throw new Error('EACCES')
+      },
+      setTimer: ((fn: () => void) => {
+        pending.push(fn)
+        return pending.length as never
+      }) as never,
+      clearTimer: (() => {}) as never
+    })
+    pending.shift()?.()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onMoved).not.toHaveBeenCalled()
+    // and it rescheduled rather than dying
+    expect(pending.length).toBe(1)
+  })
+
+  it('stops searching once unsubscribed', async () => {
+    const h = harness({ quietFor: 5_000, successor: SUCCESSOR })
+    h.stop()
+    await h.fire()
+    expect(h.onMoved).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/native-chat/transcript-rebind-watch.ts
+++ b/src/main/native-chat/transcript-rebind-watch.ts
@@ -1,0 +1,138 @@
+import { stat } from 'node:fs/promises'
+import { findSuccessorTranscript, type TranscriptSuccessor } from './claude-transcript-successor'
+import type { AgentType } from '../../shared/native-chat-types'
+
+/**
+ * How often to ask whether this session's transcript still lives where the
+ * watcher bound to it.
+ *
+ * Slow on purpose: the answer changes only when the agent rolls to a new file,
+ * and chat is not waiting on it — the installed watcher keeps delivering the
+ * whole time. This trades latency on a rare event for near-zero cost on the
+ * common one.
+ */
+const REBIND_CHECK_INTERVAL_MS = 30_000
+/** Only look for a successor once the bound file has gone this long unwritten. */
+const QUIET_BEFORE_SEARCH_MS = 120_000
+
+export type RebindWatch = { stop: () => void }
+
+/** setTimeout's handle differs between the DOM and Node lib types. */
+type RebindTimer = ReturnType<typeof setTimeout>
+
+type Args = {
+  agent: AgentType
+  /** The session id the bound file belongs to. */
+  sessionId: string
+  /** The path the live watcher is bound to. */
+  boundPath: string
+  /** Called with the file and id the session continued into. */
+  onMoved: (next: TranscriptSuccessor) => void
+  signal?: AbortSignal
+  intervalMs?: number
+  quietBeforeSearchMs?: number
+  setTimer?: (fn: () => void, ms: number) => RebindTimer
+  clearTimer?: (timer: RebindTimer) => void
+  findSuccessor?: typeof findSuccessorTranscript
+  mtimeMs?: (path: string) => Promise<number>
+  now?: () => number
+}
+
+/**
+ * Notices when a watched transcript stops being the session's transcript.
+ *
+ * A watcher binds to a path once and holds that descriptor for the life of the
+ * subscription. That is right until the file stops being the one the agent
+ * writes — then the watcher stays healthy, reports `watching: true`, and
+ * delivers nothing, which is indistinguishable from an idle conversation. One
+ * such bind sat unnoticed for seven hours: the chat list stopped at the dead
+ * file's last message, push notifications kept re-announcing that same message
+ * because they read the same transcript, and messages sent from the phone never
+ * echoed back because the echo retires by finding its text in the transcript.
+ *
+ * The trigger is a POSITIVE STATEMENT OF DESCENT — a newer sibling that replays
+ * our rows under our session id — never a quiet file. Quiet is only a cheap
+ * pre-filter: an idle session is quiet too, but it has no successor, so it never
+ * rebinds. See claude-transcript-successor.ts for why the resolver cannot answer
+ * this (the old file still exists at exactly `<old-id>.jsonl`).
+ *
+ * A failed search leaves the current watcher alone. The file it holds is the
+ * best answer available, and dropping a live binding because one probe raced a
+ * rename would turn a transient into an outage.
+ */
+export function watchForTranscriptRebind(args: Args): RebindWatch {
+  const {
+    agent,
+    sessionId,
+    boundPath,
+    onMoved,
+    signal,
+    intervalMs = REBIND_CHECK_INTERVAL_MS,
+    quietBeforeSearchMs = QUIET_BEFORE_SEARCH_MS,
+    setTimer = (fn, ms) => setTimeout(fn, ms) as RebindTimer,
+    clearTimer = (handle) => clearTimeout(handle as Parameters<typeof clearTimeout>[0]),
+    findSuccessor = findSuccessorTranscript,
+    mtimeMs = async (path: string) => (await stat(path)).mtimeMs,
+    now = Date.now
+  } = args
+
+  let stopped = false
+  let timer: RebindTimer | null = null
+
+  function stop(): void {
+    if (stopped) {
+      return
+    }
+    stopped = true
+    if (timer !== null) {
+      clearTimer(timer)
+      timer = null
+    }
+  }
+
+  function schedule(): void {
+    if (stopped || signal?.aborted) {
+      return
+    }
+    timer = setTimer(() => {
+      timer = null
+      void check()
+    }, intervalMs)
+  }
+
+  async function check(): Promise<void> {
+    if (stopped || signal?.aborted) {
+      return
+    }
+    try {
+      const quietFor = now() - (await mtimeMs(boundPath))
+      if (quietFor >= quietBeforeSearchMs) {
+        const next = await findSuccessorTranscriptSafely()
+        if (next && next.path !== boundPath) {
+          if (!stopped && !signal?.aborted) {
+            onMoved(next)
+          }
+          return
+        }
+      }
+    } catch {
+      // Why swallow: a probe can fail transiently (a stalled WSL distro, an
+      // EACCES mid-scan). The bound watcher is still the best available answer.
+    }
+    schedule()
+  }
+
+  async function findSuccessorTranscriptSafely(): Promise<TranscriptSuccessor | null> {
+    // Only Claude rolls a session into a new file this way; the other agents
+    // keep appending, so searching their roots would only find strangers.
+    if (agent !== 'claude') {
+      return null
+    }
+    return findSuccessor(
+      signal === undefined ? { boundPath, sessionId } : { boundPath, sessionId, signal }
+    )
+  }
+
+  schedule()
+  return { stop }
+}

--- a/src/main/native-chat/transcript-watch-contract.ts
+++ b/src/main/native-chat/transcript-watch-contract.ts
@@ -33,6 +33,8 @@ export type SubscribeNativeChatTranscriptArgs = ResolveSessionFileOptions & {
   debounceMs?: number
   /** Test-only override for the production resolve-poll backoff. */
   resolvePollIntervalMs?: number
+  /** How often to check whether the session rolled to a new file; tests shorten it. */
+  rebindCheckIntervalMs?: number
   /** Test-only override for the host-side watcher reconciliation interval. */
   reconciliationIntervalMs?: number
 }

--- a/src/main/native-chat/transcript-watch-rebind.test.ts
+++ b/src/main/native-chat/transcript-watch-rebind.test.ts
@@ -1,0 +1,136 @@
+/**
+ * A compacted Claude session continues in a NEW file, and the id the watcher
+ * holds still resolves to the OLD one — that file is exactly `<old-id>.jsonl`
+ * and still exists. So the subscription stayed bound to a file nobody writes,
+ * reported `watching: true`, and delivered nothing for seven hours: the chat
+ * stopped at the dead file's last message, push kept re-announcing that same
+ * message, and phone-sent messages never echoed back.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  install: vi.fn(),
+  resolve: vi.fn(),
+  findSuccessor: vi.fn(),
+  mtimeMs: vi.fn()
+}))
+
+vi.mock('./session-file-resolver', () => ({ resolveSessionFilePath: mocks.resolve }))
+vi.mock('./transcript-watch-engine', () => ({
+  getActiveNativeChatWatcherCount: vi.fn(() => 0),
+  installTranscriptWatcher: mocks.install
+}))
+vi.mock('./claude-transcript-successor', () => ({
+  findSuccessorTranscript: mocks.findSuccessor
+}))
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  stat: async (path: string) => ({ mtimeMs: await mocks.mtimeMs(path) })
+}))
+
+import { subscribeNativeChatTranscript } from './transcript-watch'
+
+const OLD = '/projects/p/old-id.jsonl'
+const NEW = '/projects/p/new-id.jsonl'
+
+function subscribe() {
+  return subscribeNativeChatTranscript({
+    agent: 'claude',
+    sessionId: 'old-id',
+    transcriptPath: OLD,
+    resolvePollIntervalMs: 10,
+    rebindCheckIntervalMs: 10,
+    onAppend: () => {},
+    onInitialSnapshot: () => {}
+  })
+}
+
+describe('a watcher follows its session when the transcript rolls', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mocks.install.mockReset()
+    mocks.resolve.mockReset().mockResolvedValue(null)
+    mocks.findSuccessor.mockReset().mockResolvedValue(null)
+    // Long quiet, so the search is allowed to run.
+    mocks.mtimeMs.mockReset().mockResolvedValue(0)
+  })
+  afterEach(() => vi.useRealTimers())
+
+  it('reinstalls on the file the session continued into', async () => {
+    const bound: string[] = []
+    mocks.install.mockImplementation(async (filePath: string) => {
+      bound.push(filePath)
+      return { unsubscribe: () => {} }
+    })
+    mocks.findSuccessor.mockResolvedValue({ path: NEW, sessionId: 'new-id' })
+
+    const sub = await subscribe()
+    await vi.advanceTimersByTimeAsync(200)
+
+    // Bound the hook's file first, then followed the session off it.
+    expect(bound[0]).toBe(OLD)
+    expect(bound.at(-1)).toBe(NEW)
+    sub.unsubscribe()
+  })
+
+  /**
+   * The trigger is descent, never silence. An idle session is quiet for hours
+   * and must be left exactly where the reader put it.
+   */
+  it('leaves a merely idle session bound where it is', async () => {
+    const bound: string[] = []
+    mocks.install.mockImplementation(async (filePath: string) => {
+      bound.push(filePath)
+      return { unsubscribe: () => {} }
+    })
+
+    const sub = await subscribe()
+    await vi.advanceTimersByTimeAsync(500)
+    expect(bound).toEqual([OLD])
+    sub.unsubscribe()
+  })
+
+  // Only the direct ancestor is replayed near enough to the top to be found, so
+  // the id must advance or the second roll is invisible.
+  it('searches under the new id after a rebind', async () => {
+    mocks.install.mockResolvedValue({ unsubscribe: () => {} })
+    mocks.findSuccessor.mockResolvedValueOnce({ path: NEW, sessionId: 'new-id' })
+
+    const sub = await subscribe()
+    await vi.advanceTimersByTimeAsync(300)
+
+    const ids = mocks.findSuccessor.mock.calls.map((c) => (c[0] as { sessionId: string }).sessionId)
+    expect(ids[0]).toBe('old-id')
+    expect(ids.at(-1)).toBe('new-id')
+    sub.unsubscribe()
+  })
+
+  // A caller that pinned one file did so on purpose.
+  it('never moves a subscription that pinned an explicit file', async () => {
+    mocks.install.mockResolvedValue({ unsubscribe: () => {} })
+    mocks.findSuccessor.mockResolvedValue({ path: NEW, sessionId: 'new-id' })
+
+    const sub = await subscribeNativeChatTranscript({
+      agent: 'claude',
+      sessionId: 'old-id',
+      filePath: OLD,
+      resolvePollIntervalMs: 10,
+      rebindCheckIntervalMs: 10,
+      onAppend: () => {},
+      onInitialSnapshot: () => {}
+    })
+    await vi.advanceTimersByTimeAsync(300)
+    expect(mocks.findSuccessor).not.toHaveBeenCalled()
+    sub.unsubscribe()
+  })
+
+  it('stops searching once unsubscribed', async () => {
+    mocks.install.mockResolvedValue({ unsubscribe: () => {} })
+    const sub = await subscribe()
+    await vi.advanceTimersByTimeAsync(50)
+    sub.unsubscribe()
+    mocks.findSuccessor.mockClear()
+    await vi.advanceTimersByTimeAsync(500)
+    expect(mocks.findSuccessor).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/native-chat/transcript-watch.ts
+++ b/src/main/native-chat/transcript-watch.ts
@@ -5,6 +5,7 @@ import {
   toHostReadableTranscriptPath
 } from './host-readable-transcript-path'
 import { resolveSessionFilePath } from './session-file-resolver'
+import { watchForTranscriptRebind, type RebindWatch } from './transcript-rebind-watch'
 import { installTranscriptWatcher } from './transcript-watch-engine'
 import type {
   NativeChatTranscriptSubscription,
@@ -76,10 +77,13 @@ function subscribeViaResolvePoll(
 ): NativeChatTranscriptSubscription {
   let closed = false
   let installed: NativeChatTranscriptSubscription | null = null
+  let rebindWatch: RebindWatch | null = null
+  /** The session the bound file belongs to; advances each time it rolls. */
+  let rebindSessionId = args.sessionId
   let pollTimer: ReturnType<typeof setTimeout> | null = null
   let delay = args.resolvePollIntervalMs ?? INITIAL_RESOLVE_POLL_MS
   let lastFallbackResolveAt = Date.now()
-  const exactPath = exactTranscriptPath(args)
+  let exactPath = exactTranscriptPath(args)
   // Why: WSL hooks report guest Linux paths the Windows host cannot open; the
   // UNC twin is resolved lazily (the distro may still be cold) and memoized so
   // the exact-path install doesn't wait on the slower id-glob (#10326).
@@ -116,6 +120,47 @@ function subscribeViaResolvePoll(
   if (args.onTranscriptPending) {
     settleTimer = setTimeout(settleUnflushed, UNFLUSHED_SETTLE_MS)
     settleTimer.unref?.()
+  }
+
+  /**
+   * Follow the session if its transcript rolls to a new file.
+   *
+   * A watcher binds once and then holds that descriptor. When the bound file
+   * stops being the one the agent writes, the watcher stays healthy, keeps
+   * reporting watching:true, and delivers nothing — indistinguishable from an
+   * idle conversation. See transcript-rebind-watch.ts for what that cost.
+   */
+  function armRebindWatch(boundPath: string | null): void {
+    rebindWatch?.stop()
+    rebindWatch = null
+    // An explicit filePath is a caller pinning one file on purpose.
+    if (!boundPath || args.filePath) {
+      return
+    }
+    rebindWatch = watchForTranscriptRebind({
+      agent: args.agent,
+      sessionId: rebindSessionId,
+      boundPath,
+      signal: resolveController.signal,
+      ...(args.rebindCheckIntervalMs === undefined
+        ? {}
+        : { intervalMs: args.rebindCheckIntervalMs }),
+      onMoved: (next) => {
+        if (closed) {
+          return
+        }
+        // Pin the successor rather than re-resolving: the id we hold still
+        // resolves to the dead file, which is the whole reason we are here.
+        // Track the new id too, so a second roll is still findable.
+        rebindSessionId = next.sessionId
+        installed?.unsubscribe()
+        installed = null
+        exactPath = next.path
+        hostReadableExactPath = null
+        delay = args.resolvePollIntervalMs ?? INITIAL_RESOLVE_POLL_MS
+        scheduleAttempt()
+      }
+    })
   }
 
   function scheduleAttempt(): void {
@@ -204,6 +249,7 @@ function subscribeViaResolvePoll(
     if (result) {
       installed = result
       stopSettleTimer()
+      armRebindWatch(hostReadableExactPath ?? exactPath ?? null)
       return
     }
     scheduleAttempt()
@@ -220,6 +266,8 @@ function subscribeViaResolvePoll(
       closed = true
       resolveController.abort()
       stopSettleTimer()
+      rebindWatch?.stop()
+      rebindWatch = null
       if (pollTimer) {
         clearTimeout(pollTimer)
         pollTimer = null

--- a/src/main/runtime/mobile-push-escalation.test.ts
+++ b/src/main/runtime/mobile-push-escalation.test.ts
@@ -230,6 +230,39 @@ describe('MobilePushEscalation', () => {
     expect(payload.aps.alert.body).toBeTruthy()
   })
 
+  /**
+   * The budget cuts the oldest, never the newest. A lock screen has room for one
+   * line and the extension reads the last item, so trimming from the back threw
+   * away the only thing the user was going to see — every push in a busy session
+   * showed the same stale message.
+   */
+  it('drops the oldest when the batch will not fit, never the newest', async () => {
+    const key = generatePushKey()
+    const h = harness({
+      pushTargets: () => [
+        { deviceId: 'd', deviceToken: 'a'.repeat(64), encryptionKeyB64: key.toString('base64') }
+      ]
+    })
+    for (let i = 0; i < 8; i += 1) {
+      h.escalation.schedule({
+        type: 'notification',
+        source: 'agent',
+        title: `t${i}`,
+        body: `${'y'.repeat(199)}${i}`
+      } as never)
+    }
+    await h.elapse()
+
+    const items = JSON.parse(decryptPushBody(key, h.wake.mock.calls[0][0].payload.mb)!) as {
+      t: string
+      b: string
+    }[]
+    expect(items.length).toBeLessThan(8)
+    // Still oldest-first on the wire, and the newest survived the trim.
+    expect(items.at(-1)?.t).toBe('t7')
+    expect(items.at(0)?.t).not.toBe('t0')
+  })
+
   it('survives a malformed key without losing the notification', async () => {
     const h = harness({
       pushTargets: () => [
@@ -280,5 +313,4 @@ describe('MobilePushEscalation', () => {
       expect(payload.de).toBeUndefined()
     })
   })
-
 })

--- a/src/main/runtime/mobile-push-escalation.ts
+++ b/src/main/runtime/mobile-push-escalation.ts
@@ -194,14 +194,23 @@ function sealedBody(
   // CJK — three bytes per character — blows the budget at three notifications
   // and the whole body is discarded, silently, exactly when there is most to
   // say.
+  //
+  // Filled newest-first so the budget cuts the OLDEST: the line a lock screen
+  // shows is the latest one, and filling forwards trimmed exactly that. The
+  // array itself stays oldest-first, so an extension still reading items[0] is
+  // unaffected by the change.
   const items: { t: string; b: string }[] = []
-  for (const event of batch) {
-    items.push({
+  for (let i = batch.length - 1; i >= 0; i--) {
+    const event = batch[i]
+    if (!event) {
+      continue
+    }
+    items.unshift({
       t: clip('title' in event ? String(event.title ?? '') : '', 120),
       b: clip('body' in event ? String(event.body ?? '') : '', 200)
     })
     if (Buffer.byteLength(JSON.stringify(items), 'utf8') > MAX_SEALED_PLAINTEXT_BYTES) {
-      items.pop()
+      items.shift()
       break
     }
   }


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​462 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​461 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​381 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​374 |

<!-- /manta-pr-loc -->

两个用户报告的 bug,根因不同但症状缠在一起:手机端聊天停在很久以前的一条消息不再更新,同时锁屏通知反复弹同一条老消息。

Base 指向 `sync/upstream-20260827`(PR #9)而非 `main`,因为改动依赖该分支引入的 `stopSettleTimer()`。#9 合并后本 PR 的 base 会自动切到 `main`。

## 1. 压缩滚动 transcript 后订阅跟丢

Claude 压缩会话时不是追加,而是**开新文件、换新 sessionId**,把旧对话回放进去 —— 旧文件原地保留。于是订阅一直绑在没人写的文件上,报告 `watching: true`、零帧,和"对方没说话"在视觉上完全一致。实测一次这样的绑定持续了 7 小时:

- 聊天列表停在死文件的最后一条
- 推送反复播报同一条(它读的是同一个 transcript)
- 手机发出的消息永远不回显(回显要靠在 transcript 里找到自己的文本才能退场)

解析器答不了这个问题:`resolveSessionFilePath` 那句"stale paths fall through to the id-based search"永远不会触发,因为旧文件就叫 `<old-id>.jsonl`,而且还在。

**判定依据是血缘的正面证据,不是"文件安静了"。** Claude 并排写两种拼写:`sessionId`(驼峰,文件自身会话,全文件一致)和 `session_id`(下划线,回放行原本属于谁)。一个更新的兄弟文件,自身会话不同却带着我们的 id,就是继任者。安静只当一层省钱的前置过滤 —— 空闲会话也安静,但它没有继任者,所以永远不会被移走。

两个设计约束值得点名:

- **按行数而非字节数设预算**:祖先标记在第 47 行,却在 540KB 处(`file-history-snapshot` 每行约 12KB)。任何"省钱"的字节窗口都会恰好把答案切掉 —— 我最初写的 512KB 版本就是这么在真实文件上返回 `null` 的。
- **一跳一跳追**:祖父要到第 3900 行才出现,超出任何合理窗口,所以重绑时同时推进 sessionId。

## 2. 推送永远显示最旧的一条

同一条链路上两个 bug 叠加:

- 扩展读 `items.first`,而批次最旧在前 → 锁屏永远显示批次里最老的。
- 桌面端字节预算超限时从**尾部**丢弃 → 丢掉的恰好是最新几条,也就是扩展唯一会显示的那些。8 条消息的实测里,被砍掉的正是 t6、t7。

改为填充时最新在前(预算切最旧),但**数组顺序在 wire 上保持最旧在前不变**,所以仍读 `items[0]` 的旧版扩展行为与今天完全一致,不会在混版本下变差。

## 验证

- `src/main/native-chat` + 通知套件:**43 文件 / 338 用例全过**
- typecheck 通过;`check:code-quality:changed` 0 findings(含 max-lines,未加任何豁免)
- 新增 3 个测试文件,每一条断言都做过变异验证 —— 把实现改坏能让对应用例变红:
  - 去掉"必须是别人的会话"的校验 → 子代理同会话文件被误判为继任者
  - 不要求 mtime 更新 / 取最旧继任者 → 各自变红
  - 拆掉重绑接线 / 不推进 sessionId → 端到端用例变红
  - 预算退回从尾部丢 → `expected 't5' to be 't7'`
- 血缘规则在真实会话文件上验证过:`d7088df0` → 正确找到 `051ba680`;最新会话 → 正确返回 `null`

## 需要两端一起发

桌面和手机都改了。只发一端测不出效果 —— 通知那条尤其是,扩展改了 `items.last`,但桌面若还在从尾部丢弃最新的,锁屏依然看不到对的内容。

https://claude.ai/code/session_0157B63ZJpcK8RxxqLz6v54K
