### PR TITLE
feat(release): tag and publish automatically after a sync

### DIFF
--- a/.claude/skills/upstream-sync/SKILL.md
+++ b/.claude/skills/upstream-sync/SKILL.md
@@ -166,6 +166,35 @@ known and each is a migration decision, not a rename: `orca.web.onboarding.v1`
 `orca.mobile.connection-log.v1.` in `mobile/src/transport/persisted-connection-log-store.ts`;
 `MANTAD_STATE_SNAPSHOT_DIR = 'orcad-state-snapshots'` under `.manta-remote/`.
 
+## Releasing
+
+A sync that lands and never ships is upstream's fixes sitting in a branch. The
+fork was three upstream releases behind when this step did not exist.
+
+```bash
+node config/scripts/cut-fork-release.mjs --dry-run   # what it would cut
+node config/scripts/cut-fork-release.mjs             # commit + tag, no push
+```
+
+It reads upstream's newest **stable** release — their line is what this fork's
+version follows, so upstream at `1.4.196` means this fork ships `1.4.196-rc.N`
+once it has merged that work — takes the rc after the highest already cut
+(from tags and release subjects, not from `package.json`, which is a working
+file and lies after a revert), never moves the base backwards, seals the skill
+bundle manifest for the version, drafts release notes from the commit subjects
+and refuses to proceed if they carry a personal identifier.
+
+**Read the drafted notes and trim them.** The draft is a changelog; a release
+note is a line of title, a sentence, and three to five bullets. Nothing about
+rationale, tradeoffs or implementation — those live in the commits.
+
+Pushing the tag is what publishes: `fork-release.yml` triggers on `v*`, builds
+all three desktop platforms, and installed copies auto-update to the result.
+The script stops before that and prints the command; `--push` does it.
+
+Mobile is a separate line (`mobile-ios-v*`, `mobile-android-v*`) and its own
+decision — a desktop sync does not imply a phone build.
+
 ## Landing it
 
 Open a pull request; merge without squash. Nothing in CI runs on a push to

--- a/.claude/skills/upstream-sync/SKILL.md
+++ b/.claude/skills/upstream-sync/SKILL.md
@@ -169,11 +169,13 @@ known and each is a migration decision, not a rename: `orca.web.onboarding.v1`
 ## Releasing
 
 A sync that lands and never ships is upstream's fixes sitting in a branch. The
-fork was three upstream releases behind when this step did not exist.
+fork was three upstream releases behind when this step did not exist, so
+`sync-finish.sh` now cuts the release itself and the release rides in the sync
+PR. **Merging that PR is what publishes** — `auto-release.yml` tags whatever
+version arrives on main, and each tag starts its build.
 
 ```bash
 node config/scripts/cut-fork-release.mjs --dry-run   # what it would cut
-node config/scripts/cut-fork-release.mjs             # commit + tag, no push
 ```
 
 It reads upstream's newest **stable** release — their line is what this fork's
@@ -181,19 +183,24 @@ version follows, so upstream at `1.4.196` means this fork ships `1.4.196-rc.N`
 once it has merged that work — takes the rc after the highest already cut
 (from tags and release subjects, not from `package.json`, which is a working
 file and lies after a revert), never moves the base backwards, seals the skill
-bundle manifest for the version, drafts release notes from the commit subjects
-and refuses to proceed if they carry a personal identifier.
+bundle manifest for the version, drafts release notes and refuses to proceed if
+they carry a personal identifier. It stops at the commit: main requires `verify`
+and `Mobile Checks`, so tagging happens on arrival, which is what makes every
+tag point at a commit those checks passed.
 
-**Read the drafted notes and trim them.** The draft is a changelog; a release
-note is a line of title, a sentence, and three to five bullets. Nothing about
-rationale, tradeoffs or implementation — those live in the commits.
+Mobile moves in the same commit when upstream's newest `mobile-android-v*` is
+ahead of `mobile/app.json`. Both platforms read that one marketing version, and
+`prepare-android-release.mjs` rejects a tag that disagrees with the committed
+one, so the bump has to be committed rather than passed at release time.
 
-Pushing the tag is what publishes: `fork-release.yml` triggers on `v*`, builds
-all three desktop platforms, and installed copies auto-update to the result.
-The script stops before that and prints the command; `--push` does it.
+**Read the drafted notes and trim them.** The draft groups upstream's commits by
+scope into a handful of bullets; it is built only from commits carrying the
+mirror's `Mirror-Of:` trailer, because without that split the fork's own sync
+plumbing gets announced as release news. A release note is a title, a sentence,
+and three to five bullets — rationale and implementation live in the commits.
 
-Mobile is a separate line (`mobile-ios-v*`, `mobile-android-v*`) and its own
-decision — a desktop sync does not imply a phone build.
+Full picture, including the one credential the automation needs:
+[`docs/reference/fork-release-automation.md`](../../../docs/reference/fork-release-automation.md).
 
 ## Landing it
 

--- a/.claude/skills/upstream-sync/sync-finish.sh
+++ b/.claude/skills/upstream-sync/sync-finish.sh
@@ -41,4 +41,8 @@ EOF
 fi
 
 echo "== verify"
-exec "$HERE/sync-verify.sh" "$MIRROR"
+"$HERE/sync-verify.sh" "$MIRROR" || exit $?
+
+# A sync that lands and never ships is upstream's fixes sitting in a branch.
+node "$ROOT/config/scripts/cut-fork-release.mjs" --dry-run 2>/dev/null | sed 's/^/   /' || true
+echo "   after the PR merges:  node config/scripts/cut-fork-release.mjs"

--- a/.claude/skills/upstream-sync/sync-finish.sh
+++ b/.claude/skills/upstream-sync/sync-finish.sh
@@ -43,6 +43,8 @@ fi
 echo "== verify"
 "$HERE/sync-verify.sh" "$MIRROR" || exit $?
 
-# A sync that lands and never ships is upstream's fixes sitting in a branch.
-node "$ROOT/config/scripts/cut-fork-release.mjs" --dry-run 2>/dev/null | sed 's/^/   /' || true
-echo "   after the PR merges:  node config/scripts/cut-fork-release.mjs"
+echo "== cut the release"
+# A sync that lands and never ships is upstream's fixes sitting in a branch. The
+# release rides in this same PR: merging it is what publishes, because
+# auto-release.yml tags whatever version arrives on main.
+node "$ROOT/config/scripts/cut-fork-release.mjs" 2>&1 | sed 's/^/   /'

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,98 @@
+name: Auto Release
+
+run-name: Auto Release ${{ github.sha }}
+
+# Turns a merged release commit into pushed tags, which is what makes a release
+# happen: `fork-release.yml` triggers on `v*`, the two mobile workflows on
+# `mobile-ios-v*` / `mobile-android-v*`.
+#
+# Why the tags are not pushed by this job's own GITHUB_TOKEN: a push made with it
+# deliberately creates no events, so the tag would land and nothing would build.
+# The push goes over SSH with a write deploy key instead — a separate credential,
+# so its push is a real push event. The alternative was worse: the macOS leg runs
+# in the `apple-signing` environment, which admits `v*` tags and nothing else, so
+# calling `fork-release.yml` as a reusable workflow from a run on main would
+# build for forty minutes and then die at the environment gate having published
+# nothing.
+#
+# Why the tags are not pushed by whoever cuts the release: main requires `verify`
+# and `Mobile Checks`, so the release commit travels through a PR anyway. Tagging
+# on arrival means a tag always points at a commit those checks passed.
+#
+# Set up once (see docs/reference/fork-release-automation.md):
+#   ssh-keygen -t ed25519 -N '' -C manta-release-tagger -f ./release_key
+#   gh api repos/$REPO/keys -f title='release-tagger (auto-release.yml)' \
+#     -f key="$(cat ./release_key.pub)" -F read_only=false
+#   gh secret set RELEASE_TAGGER_KEY --repo $REPO < ./release_key
+#   rm ./release_key ./release_key.pub
+#
+# Without the secret this job says what it would have tagged and stops green: a
+# missing credential is a setup gap, not a broken build.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    if: github.repository == 'paidaxingyo666/Manta'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Decide which tags this commit is missing
+        id: decide
+        env:
+          # Zeroes on a dispatch or a first push; the script reads that as
+          # "compare against the parent", not as "release everything".
+          BEFORE: ${{ github.event.before }}
+        run: node config/scripts/pending-release-tags.mjs
+
+      # The secrets context is not dependable inside a step `if`, so the presence
+      # of the credential is established by a step that can read it.
+      - name: Look for the tagging credential
+        id: credential
+        if: steps.decide.outputs.tags != ''
+        env:
+          DEPLOY_KEY: ${{ secrets.RELEASE_TAGGER_KEY }}
+        run: |
+          if [ -n "$DEPLOY_KEY" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Would tag ${{ steps.decide.outputs.tags }}, but RELEASE_TAGGER_KEY is not set."
+            echo "::warning::See docs/reference/fork-release-automation.md to set it up."
+          fi
+
+      - name: Push the tags
+        if: steps.credential.outputs.present == 'true'
+        env:
+          DEPLOY_KEY: ${{ secrets.RELEASE_TAGGER_KEY }}
+          TAGS: ${{ steps.decide.outputs.tags }}
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/release_key
+          chmod 600 ~/.ssh/release_key
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts 2>/dev/null
+          export GIT_SSH_COMMAND='ssh -i ~/.ssh/release_key -o IdentitiesOnly=yes'
+          git remote set-url --push origin "git@github.com:${GITHUB_REPOSITORY}.git"
+          for tag in $TAGS; do
+            git tag "$tag" "$GITHUB_SHA"
+          done
+          # One push, but GitHub raises a create event per ref, so each tag starts
+          # its own build.
+          git push origin $TAGS
+          echo "::notice::Tagged $TAGS — the release workflows are building."

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -13,24 +13,60 @@ on:
       - 'src/shared/terminal-file-link-conformance.ts'
       - '.github/workflows/mobile.yml'
       - '.github/workflows/mobile-ios-release.yml'
+  # Why no `paths:` here, unlike the push trigger: `Mobile Checks` is a required
+  # status check on main. A workflow skipped by a path filter creates no check at
+  # all, so every pull request that does not touch mobile waits forever on a
+  # context that will never appear — which blocked one. A job skipped by its own
+  # `if:` does create the check, and branch protection counts it as passing, so
+  # the filtering moves from the trigger down to the job below.
   pull_request:
     types:
       - opened
       - synchronize
       - reopened
       - ready_for_review
-    paths:
-      - 'mobile/**'
-      # Why: the mobile terminal link parsers are conformance-tested against
-      # these shared fixtures; desktop-side fixture edits must re-run this suite.
-      - 'src/shared/terminal-file-link-conformance.ts'
-      # Why: this job holds the only checks that load the Fastfile, so edits to
-      # it or to the release workflow it guards must re-run them.
-      - '.github/workflows/mobile.yml'
-      - '.github/workflows/mobile-ios-release.yml'
 
 jobs:
+  changes:
+    name: detect mobile changes
+    runs-on: ubuntu-latest
+    outputs:
+      mobile: ${{ steps.filter.outputs.mobile }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # blob:none: the merge-base diff needs full history but no old blobs.
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
+
+      - name: Classify changed paths
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BASE_SHA:-}" ]; then
+            echo "mobile=true" | tee -a "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # --no-renames: a rename reported name-only can hide the source path.
+          CHANGED="$(git diff --name-only --no-renames --diff-filter=ACDMR --merge-base "$BASE_SHA" "$HEAD_SHA")"
+          printf '%s\n' "$CHANGED"
+          # The same four patterns the push trigger filters on: mobile itself,
+          # the shared fixtures its terminal link parsers are conformance-tested
+          # against, and the two workflows whose Fastfile nothing else loads.
+          if printf '%s\n' "$CHANGED" | grep -Eq '^(mobile/|src/shared/terminal-file-link-conformance\.ts$|\.github/workflows/mobile(\.yml|-ios-release\.yml)$)'; then
+            echo "mobile=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "mobile=false" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   verify:
+    needs: [changes]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.mobile == 'true'
     # Why a display name: pr.yml's gate job is also `verify`, and two jobs with
     # one context name are one required check to branch protection — a red
     # mobile run hid behind a green desktop one.

--- a/config/scripts/auto-release-workflow-contract.test.mjs
+++ b/config/scripts/auto-release-workflow-contract.test.mjs
@@ -1,0 +1,90 @@
+/**
+ * Shape checks for the automation that turns a merged release commit into
+ * pushed tags.
+ *
+ * Everything here fails silently in production if it drifts: a tag lands and no
+ * build starts, or no tag lands at all, and the only symptom is a release that
+ * never appears. None of it is caught by running the workflow, because the
+ * workflow succeeds either way.
+ */
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+import { pendingReleaseTags } from './pending-release-tags.mjs'
+
+const projectDir = resolve(import.meta.dirname, '../..')
+const workflowsDir = join(projectDir, '.github/workflows')
+const workflow = (file) => parse(readFileSync(join(workflowsDir, file), 'utf8'))
+const autoReleaseText = readFileSync(join(workflowsDir, 'auto-release.yml'), 'utf8')
+
+// `on:` parses as the boolean true — YAML 1.1, which the Actions parser is not.
+const triggers = (parsed) => parsed.on ?? parsed[true]
+
+/** Tag patterns each release workflow starts on, e.g. ['v*']. */
+const tagTriggers = (file) => triggers(workflow(file))?.push?.tags ?? []
+
+describe('auto release workflow contract', () => {
+  it('runs on pushes to main', () => {
+    expect(triggers(workflow('auto-release.yml')).push.branches).toEqual(['main'])
+  })
+
+  it('emits tags the release workflows actually trigger on', () => {
+    // The coupling that breaks quietly: if a release workflow narrows its tag
+    // pattern, the automation keeps pushing tags nothing listens for.
+    const emitted = pendingReleaseTags(
+      {
+        desktop: '1.4.196-rc.0',
+        previousDesktop: '1.4.193-rc.0',
+        mobile: '0.0.47',
+        previousMobile: '0.0.44'
+      },
+      () => false
+    )
+    const patterns = [
+      ...tagTriggers('fork-release.yml'),
+      ...tagTriggers('mobile-ios-release.yml'),
+      ...tagTriggers('mobile-android-release.yml')
+    ]
+    const matches = (tag) =>
+      patterns.some((pattern) => new RegExp(`^${pattern.replaceAll('*', '.*')}$`).test(tag))
+
+    expect(emitted).toHaveLength(3)
+    for (const tag of emitted) {
+      expect(matches(tag), `${tag} matches no release workflow trigger`).toBe(true)
+    }
+  })
+
+  it('pushes the tags with the deploy key, not the job token', () => {
+    // A push made with GITHUB_TOKEN deliberately raises no events, so the tag
+    // would land and nothing would build — a green run that shipped nothing.
+    const steps = Object.values(workflow('auto-release.yml').jobs).flatMap((job) => job.steps ?? [])
+    const push = steps.find((step) => String(step.run ?? '').includes('git push origin'))
+    expect(push).toBeDefined()
+    expect(push.env.DEPLOY_KEY).toContain('RELEASE_TAGGER_KEY')
+    expect(push.run).toContain('GIT_SSH_COMMAND')
+    expect(push.run).toContain('git@github.com:')
+  })
+
+  it('asks for no more write access than it uses', () => {
+    // The tags go out over SSH, so the job token needs nothing but a checkout.
+    expect(workflow('auto-release.yml').permissions).toEqual({ contents: 'read' })
+  })
+
+  it('stays green when the credential is missing', () => {
+    // A setup gap must not read as a broken build, or every sync merge goes red
+    // until someone sets a secret that has nothing to do with the sync.
+    const steps = Object.values(workflow('auto-release.yml').jobs).flatMap((job) => job.steps ?? [])
+    const push = steps.find((step) => String(step.run ?? '').includes('git push origin'))
+    expect(push.if).toContain('present')
+    expect(autoReleaseText).toContain('::warning::')
+  })
+
+  it('documents the setup the automation cannot do for itself', () => {
+    expect(autoReleaseText).toContain('docs/reference/fork-release-automation.md')
+    expect(
+      readFileSync(join(projectDir, 'docs/reference/fork-release-automation.md'), 'utf8')
+    ).toContain('RELEASE_TAGGER_KEY')
+  })
+})

--- a/config/scripts/cut-fork-release.mjs
+++ b/config/scripts/cut-fork-release.mjs
@@ -65,6 +65,37 @@ function fail(message) {
 const MOBILE_TAG = /^mobile-android-v([0-9]+\.[0-9]+\.[0-9]+)$/
 
 /**
+ * mobile/app.json with the marketing version set and versionCode advanced by
+ * one, by substitution rather than by re-serializing.
+ *
+ * JSON.stringify reflows the file — its single-line
+ * NSPrivacyAccessedAPITypeReasons arrays become six lines each, nineteen lines
+ * of noise around a two-line change. app.json is a file upstream edits, so that
+ * noise comes back as a merge conflict on every sync.
+ */
+export function bumpMobileAppConfig(text, version) {
+  const replaceOnce = (source, pattern, replacement) => {
+    const all = source.match(new RegExp(pattern.source, 'g'))
+    if (all?.length !== 1) {
+      throw new Error(`mobile/app.json: ${pattern} matched ${all?.length ?? 0} times, expected 1`)
+    }
+    return source.replace(pattern, replacement)
+  }
+  const withVersion = replaceOnce(
+    text,
+    /("version":\s*")[0-9]+\.[0-9]+\.[0-9]+(")/,
+    `$1${version}$2`
+  )
+  // Android refuses to install an APK numbered below the one on the device, so
+  // this only ever counts up — never down, never reset by a version change.
+  return replaceOnce(
+    withVersion,
+    /("versionCode":\s*)([0-9]+)/,
+    (_, key, code) => `${key}${Number(code) + 1}`
+  )
+}
+
+/**
  * Upstream's newest mobile release. The phone app has its own version line
  * (0.0.x) and its own release cadence, but the same rule applies: this fork
  * ships what upstream shipped, once it has merged it. Android's tag is the
@@ -138,9 +169,7 @@ function bumpMobileVersion(upstreamMobile, { write }) {
     return null
   }
   if (write) {
-    config.expo.version = upstreamMobile
-    config.expo.android.versionCode = Number(config.expo.android.versionCode) + 1
-    writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`)
+    writeFileSync(configPath, bumpMobileAppConfig(readFileSync(configPath, 'utf8'), upstreamMobile))
   }
   return { version: upstreamMobile, from: current }
 }

--- a/config/scripts/cut-fork-release.mjs
+++ b/config/scripts/cut-fork-release.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+/**
+ * Cut this fork's next release: pick the version, write the notes, seal the
+ * skill manifest, commit and tag.
+ *
+ * Pushing the tag is what publishes — `fork-release.yml` triggers on `v*` and
+ * builds macOS, Windows and Linux, and installed copies auto-update to what it
+ * publishes. So this stops at the tag by default and prints the push command;
+ * `--push` does it.
+ *
+ * The version follows upstream's line, which is why a sync is the natural time
+ * to run this: upstream ships 1.4.196, this fork ships 1.4.196-rc.N once it has
+ * merged that work. The base never moves backwards, and an rc number is never
+ * reused — `release-rc-history.mjs` reads what has already been cut from tags
+ * and release subjects rather than trusting package.json, which is a working
+ * file and lies after a revert.
+ *
+ * Usage:
+ *   cut-fork-release.mjs [--version X.Y.Z-rc.N] [--push] [--dry-run]
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+
+import { fetchReleases, latestStableDesktopReleaseTag } from './latest-stable-release.mjs'
+import { highestRcForBase } from './release-rc-history.mjs'
+
+const UPSTREAM_REPO = 'stablyai/orca'
+// Anything that identifies the maintainer personally. Release notes become the
+// GitHub Release body and the in-app update card, so they are public.
+const PRIVATE_PATTERNS = [
+  /paidaxingyo666/i,
+  /Li ChangQing/i,
+  /G5J7URYYG5/,
+  /manta\.sh\.cn/i,
+  /\b\d{1,3}(\.\d{1,3}){3}\b/,
+  /bruceli/i
+]
+
+const root = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim()
+const args = process.argv.slice(2)
+const flag = (name) => args.includes(name)
+const value = (name) => {
+  const i = args.indexOf(name)
+  return i === -1 ? null : args[i + 1]
+}
+const dryRun = flag('--dry-run')
+
+function git(...rest) {
+  return execFileSync('git', rest, { cwd: root, encoding: 'utf8' }).trim()
+}
+
+function fail(message) {
+  console.error(`✗ ${message}`)
+  process.exit(1)
+}
+
+/** Upstream's newest shipped release, which is the line this fork's version follows. */
+async function upstreamStableBase() {
+  let token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN
+  if (!token) {
+    try {
+      token = execFileSync('gh', ['auth', 'token'], { encoding: 'utf8' }).trim()
+    } catch {
+      fail('no GitHub token: set GITHUB_TOKEN or run `gh auth login`')
+    }
+  }
+  const tag = latestStableDesktopReleaseTag(await fetchReleases(UPSTREAM_REPO, token))
+  if (!tag) {
+    fail(`${UPSTREAM_REPO} has no stable vX.Y.Z release`)
+  }
+  return tag.replace(/^v/, '')
+}
+
+function compareBases(a, b) {
+  const left = a.split('.').map(Number)
+  const right = b.split('.').map(Number)
+  for (let i = 0; i < 3; i += 1) {
+    if ((left[i] ?? 0) !== (right[i] ?? 0)) {
+      return (left[i] ?? 0) - (right[i] ?? 0)
+    }
+  }
+  return 0
+}
+
+/**
+ * Notes for a version that has none yet: the merged subjects since the last
+ * release, for someone to distil. Left long on purpose — trimming is a judgment
+ * call, and a scaffold that reads like a changelog is easier to cut down than a
+ * blank file is to fill.
+ */
+function draftReleaseNotes(version, previousTag) {
+  const range = previousTag ? `${previousTag}..HEAD` : 'HEAD'
+  const subjects = git('log', '--format=%s', '--no-merges', range)
+    .split('\n')
+    .filter(Boolean)
+    .filter((subject) => !/^(chore|docs|style|test|ci)\(sync\)|^sync:/i.test(subject))
+    .slice(0, 40)
+  return [
+    `# ${version}`,
+    '',
+    'Picks up upstream fixes and features.',
+    '',
+    ...subjects.map((subject) => `- ${subject}`),
+    ''
+  ].join('\n')
+}
+
+function assertNoPrivateIdentifiers(file) {
+  const text = readFileSync(file, 'utf8')
+  const hits = PRIVATE_PATTERNS.filter((pattern) => pattern.test(text)).map(String)
+  if (hits.length > 0) {
+    fail(`release notes carry personal identifiers (${hits.join(', ')}): ${file}`)
+  }
+}
+
+async function main() {
+  if (git('rev-parse', '--abbrev-ref', 'HEAD') !== 'main') {
+    fail('cut releases from main')
+  }
+  if (git('status', '--porcelain', '--untracked-files=no')) {
+    fail('working tree is not clean')
+  }
+  git('fetch', '--quiet', 'origin', 'main')
+  if (git('rev-parse', 'HEAD') !== git('rev-parse', 'origin/main')) {
+    fail('main is not in sync with origin/main')
+  }
+
+  const packagePath = path.join(root, 'package.json')
+  const manifest = JSON.parse(readFileSync(packagePath, 'utf8'))
+  const currentBase = manifest.version.split('-')[0]
+
+  let version = value('--version')
+  if (!version) {
+    const upstreamBase = await upstreamStableBase()
+    // Never backwards: a fork-only fix cut ahead of upstream keeps its base.
+    const base = compareBases(upstreamBase, currentBase) > 0 ? upstreamBase : currentBase
+    const highest = highestRcForBase(base, { cwd: root })
+    version = `${base}-rc.${highest === null ? 0 : highest + 1}`
+    console.log(`  upstream stable ${upstreamBase} · fork at ${manifest.version} → ${version}`)
+  }
+  const tag = `v${version}`
+  if (git('tag', '--list', tag)) {
+    fail(`${tag} already exists locally`)
+  }
+  if (
+    execFileSync('git', ['ls-remote', '--tags', 'origin', tag], {
+      cwd: root,
+      encoding: 'utf8'
+    }).trim()
+  ) {
+    fail(`${tag} already exists on origin`)
+  }
+
+  // Not `--merged HEAD`: the 2026-09-02 cutover put main on a generated mirror
+  // of upstream, so every tag cut before it is reachable only from main-legacy.
+  // Newest by version is what "since the last release" means here regardless.
+  const previousTag =
+    git('tag', '--list', 'v*', '--sort=-v:refname').split('\n').find(Boolean) ?? null
+  const notesPath = path.join(root, 'docs', 'release-notes', `${version}.md`)
+  const notesExist = existsSync(notesPath)
+
+  if (dryRun) {
+    console.log(`\n  would cut ${tag}`)
+    console.log(`  since: ${previousTag ?? '(no previous tag)'}`)
+    console.log(
+      `  notes: ${path.relative(root, notesPath)}${
+        notesExist
+          ? ' (already written)'
+          : ` (would draft from ${
+              draftReleaseNotes(version, previousTag)
+                .split('\n')
+                .filter((line) => line.startsWith('- ')).length
+            } commit subjects)`
+      }`
+    )
+    process.exit(0)
+  }
+
+  const wroteDraft = !notesExist
+  if (wroteDraft) {
+    mkdirSync(path.dirname(notesPath), { recursive: true })
+    writeFileSync(notesPath, draftReleaseNotes(version, previousTag))
+  }
+  assertNoPrivateIdentifiers(notesPath)
+
+  manifest.version = version
+  writeFileSync(packagePath, `${JSON.stringify(manifest, null, 2)}\n`)
+  // Seal the manifest for this version: left unsealed, the next regeneration
+  // reassigns a revision number to different bytes and every installed copy
+  // stops matching a known snapshot.
+  execFileSync(
+    'node',
+    ['config/scripts/generate-skill-bundle-manifest.mjs', '--release', version],
+    {
+      cwd: root,
+      stdio: 'inherit'
+    }
+  )
+
+  git('add', 'package.json', 'resources/skills', path.relative(root, notesPath))
+  execFileSync(
+    'git',
+    ['-c', 'core.hooksPath=/dev/null', 'commit', '-q', '-m', `chore(release): cut ${version}`],
+    {
+      cwd: root
+    }
+  )
+  git('tag', tag)
+  console.log(`\n  ${tag} committed and tagged at ${git('rev-parse', '--short', 'HEAD')}`)
+  if (wroteDraft) {
+    console.log(
+      `  notes were drafted from commit subjects — read ${path.relative(root, notesPath)} and trim it`
+    )
+    console.log('  (amend the commit and re-tag with `git tag -f` if you edit them)')
+  }
+
+  if (flag('--push')) {
+    git('push', 'origin', 'main')
+    git('push', 'origin', tag)
+    console.log(`  pushed — fork-release.yml is building ${tag}`)
+  } else {
+    console.log(`\n  publish with:  git push origin main && git push origin ${tag}`)
+  }
+}
+
+main().catch((error) => fail(error.message))

--- a/config/scripts/cut-fork-release.mjs
+++ b/config/scripts/cut-fork-release.mjs
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 /**
- * Cut this fork's next release: pick the version, write the notes, seal the
- * skill manifest, commit and tag.
+ * Cut this fork's next release: pick the version, write the notes, bump the
+ * desktop and mobile manifests, seal the skill bundle, commit.
  *
- * Pushing the tag is what publishes — `fork-release.yml` triggers on `v*` and
- * builds macOS, Windows and Linux, and installed copies auto-update to what it
- * publishes. So this stops at the tag by default and prints the push command;
- * `--push` does it.
+ * It stops at the commit. Tagging is `auto-release.yml`'s job, which runs on
+ * every push to main and pushes whatever tag package.json and mobile/app.json
+ * say is missing. So a release travels the same road as every other change — a
+ * branch, a PR, the required checks — and merging it is what publishes.
+ *
+ * Why not tag here and push to main directly: main requires `verify` and
+ * `Mobile Checks`, so a freshly made commit cannot be pushed to it at all. And a
+ * release that skipped the checks would be the one release nothing verified.
  *
  * The version follows upstream's line, which is why a sync is the natural time
  * to run this: upstream ships 1.4.196, this fork ships 1.4.196-rc.N once it has
@@ -16,14 +20,16 @@
  * file and lies after a revert.
  *
  * Usage:
- *   cut-fork-release.mjs [--version X.Y.Z-rc.N] [--push] [--dry-run]
+ *   cut-fork-release.mjs [--version X.Y.Z-rc.N] [--dry-run]
  */
 import { execFileSync } from 'node:child_process'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
+import { pathToFileURL } from 'node:url'
 
 import { fetchReleases, latestStableDesktopReleaseTag } from './latest-stable-release.mjs'
+import { draftReleaseNotes } from './release-notes-draft.mjs'
 import { highestRcForBase } from './release-rc-history.mjs'
 
 const UPSTREAM_REPO = 'stablyai/orca'
@@ -56,6 +62,32 @@ function fail(message) {
   process.exit(1)
 }
 
+const MOBILE_TAG = /^mobile-android-v([0-9]+\.[0-9]+\.[0-9]+)$/
+
+/**
+ * Upstream's newest mobile release. The phone app has its own version line
+ * (0.0.x) and its own release cadence, but the same rule applies: this fork
+ * ships what upstream shipped, once it has merged it. Android's tag is the
+ * marketing version both platforms read out of mobile/app.json; iOS publishes
+ * to TestFlight and has no GitHub release to read.
+ */
+export function upstreamMobileVersion(releases) {
+  const versions = releases
+    .map((release) => MOBILE_TAG.exec(release.tag_name ?? '')?.[1])
+    .filter(Boolean)
+    .sort((a, b) => {
+      const l = a.split('.').map(Number)
+      const r = b.split('.').map(Number)
+      for (let i = 0; i < 3; i += 1) {
+        if ((l[i] ?? 0) !== (r[i] ?? 0)) {
+          return (l[i] ?? 0) - (r[i] ?? 0)
+        }
+      }
+      return 0
+    })
+  return versions.at(-1) ?? null
+}
+
 /** Upstream's newest shipped release, which is the line this fork's version follows. */
 async function upstreamStableBase() {
   let token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN
@@ -66,11 +98,12 @@ async function upstreamStableBase() {
       fail('no GitHub token: set GITHUB_TOKEN or run `gh auth login`')
     }
   }
-  const tag = latestStableDesktopReleaseTag(await fetchReleases(UPSTREAM_REPO, token))
+  const releases = await fetchReleases(UPSTREAM_REPO, token)
+  const tag = latestStableDesktopReleaseTag(releases)
   if (!tag) {
     fail(`${UPSTREAM_REPO} has no stable vX.Y.Z release`)
   }
-  return tag.replace(/^v/, '')
+  return { desktop: tag.replace(/^v/, ''), mobile: upstreamMobileVersion(releases) }
 }
 
 function compareBases(a, b) {
@@ -85,26 +118,53 @@ function compareBases(a, b) {
 }
 
 /**
- * Notes for a version that has none yet: the merged subjects since the last
- * release, for someone to distil. Left long on purpose — trimming is a judgment
- * call, and a scaffold that reads like a changelog is easier to cut down than a
- * blank file is to fill.
+ * Move the phone app onto upstream's mobile version, if upstream has shipped one
+ * this fork has not. Both platforms read the marketing version out of
+ * mobile/app.json — `prepare-android-release.mjs` refuses a tag that disagrees
+ * with the committed one, and iOS falls back to it — so the bump has to be a
+ * commit, not a release-time argument. versionCode only ever goes up: Android
+ * refuses to install an APK numbered below the one on the device.
+ *
+ * Returns the version cut, or null when upstream is not ahead.
  */
-function draftReleaseNotes(version, previousTag) {
-  const range = previousTag ? `${previousTag}..HEAD` : 'HEAD'
-  const subjects = git('log', '--format=%s', '--no-merges', range)
+function bumpMobileVersion(upstreamMobile, { write }) {
+  if (!upstreamMobile) {
+    return null
+  }
+  const configPath = path.join(root, 'mobile', 'app.json')
+  const config = JSON.parse(readFileSync(configPath, 'utf8'))
+  const current = String(config.expo.version)
+  if (compareBases(upstreamMobile, current) <= 0) {
+    return null
+  }
+  if (write) {
+    config.expo.version = upstreamMobile
+    config.expo.android.versionCode = Number(config.expo.android.versionCode) + 1
+    writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`)
+  }
+  return { version: upstreamMobile, from: current }
+}
+
+/**
+ * Commits since the previous release, each flagged with whether it came from
+ * upstream. The `Mirror-Of:` trailer is the mirror's own record of which
+ * upstream commit a replayed commit is; a commit without one is the fork's.
+ */
+function commitsSincePreviousTag(previousTag) {
+  // git's own escape, not a literal separator in argv: Node refuses to pass a
+  // NUL byte to execFile, and a printable separator can appear in a subject.
+  return git(
+    'log',
+    '--format=%s%x1f%(trailers:key=Mirror-Of,valueonly=true)',
+    '--no-merges',
+    previousTag ? `${previousTag}..HEAD` : 'HEAD'
+  )
     .split('\n')
     .filter(Boolean)
-    .filter((subject) => !/^(chore|docs|style|test|ci)\(sync\)|^sync:/i.test(subject))
-    .slice(0, 40)
-  return [
-    `# ${version}`,
-    '',
-    'Picks up upstream fixes and features.',
-    '',
-    ...subjects.map((subject) => `- ${subject}`),
-    ''
-  ].join('\n')
+    .map((line) => {
+      const [subject, mirrorOf = ''] = line.split('\u001f')
+      return { subject, upstream: mirrorOf.trim() !== '' }
+    })
 }
 
 function assertNoPrivateIdentifiers(file) {
@@ -116,42 +176,52 @@ function assertNoPrivateIdentifiers(file) {
 }
 
 async function main() {
-  if (git('rev-parse', '--abbrev-ref', 'HEAD') !== 'main') {
-    fail('cut releases from main')
+  const branch = git('rev-parse', '--abbrev-ref', 'HEAD')
+  if (branch === 'main') {
+    fail('cut on a branch, not main — the release commit goes through a PR like anything else')
   }
   if (git('status', '--porcelain', '--untracked-files=no')) {
     fail('working tree is not clean')
   }
   git('fetch', '--quiet', 'origin', 'main')
-  if (git('rev-parse', 'HEAD') !== git('rev-parse', 'origin/main')) {
-    fail('main is not in sync with origin/main')
+  // Cutting from a branch that is behind main would compute the version from a
+  // stale upstream base and write notes missing whatever landed in between.
+  try {
+    execFileSync('git', ['merge-base', '--is-ancestor', 'origin/main', 'HEAD'], { cwd: root })
+  } catch {
+    fail(`${branch} is behind origin/main — rebase before cutting`)
   }
 
   const packagePath = path.join(root, 'package.json')
   const manifest = JSON.parse(readFileSync(packagePath, 'utf8'))
   const currentBase = manifest.version.split('-')[0]
 
+  const upstream = await upstreamStableBase()
+  // Never backwards: a fork-only fix cut ahead of upstream keeps its base.
+  const base = compareBases(upstream.desktop, currentBase) > 0 ? upstream.desktop : currentBase
   let version = value('--version')
   if (!version) {
-    const upstreamBase = await upstreamStableBase()
-    // Never backwards: a fork-only fix cut ahead of upstream keeps its base.
-    const base = compareBases(upstreamBase, currentBase) > 0 ? upstreamBase : currentBase
     const highest = highestRcForBase(base, { cwd: root })
     version = `${base}-rc.${highest === null ? 0 : highest + 1}`
-    console.log(`  upstream stable ${upstreamBase} · fork at ${manifest.version} → ${version}`)
+    console.log(`  upstream stable ${upstream.desktop} · fork at ${manifest.version} → ${version}`)
+  }
+  // origin, not the local tag list: this clone fetches upstream, so upstream's
+  // own tags live here — all 22 of its mobile-android-v* among them. The fork
+  // follows upstream's mobile version, so every mobile tag it is about to cut
+  // collides locally with the upstream tag of the same name and no fork tag at
+  // all. What matters is whether the tag has been published to this fork.
+  const assertTagIsFree = (name) => {
+    if (
+      execFileSync('git', ['ls-remote', '--tags', 'origin', name], {
+        cwd: root,
+        encoding: 'utf8'
+      }).trim()
+    ) {
+      fail(`${name} already exists on origin`)
+    }
   }
   const tag = `v${version}`
-  if (git('tag', '--list', tag)) {
-    fail(`${tag} already exists locally`)
-  }
-  if (
-    execFileSync('git', ['ls-remote', '--tags', 'origin', tag], {
-      cwd: root,
-      encoding: 'utf8'
-    }).trim()
-  ) {
-    fail(`${tag} already exists on origin`)
-  }
+  assertTagIsFree(tag)
 
   // Not `--merged HEAD`: the 2026-09-02 cutover put main on a generated mirror
   // of upstream, so every tag cut before it is reachable only from main-legacy.
@@ -161,18 +231,31 @@ async function main() {
   const notesPath = path.join(root, 'docs', 'release-notes', `${version}.md`)
   const notesExist = existsSync(notesPath)
 
+  const mobile = bumpMobileVersion(upstream.mobile, { write: false })
+  if (mobile) {
+    assertTagIsFree(`mobile-ios-v${mobile.version}`)
+    assertTagIsFree(`mobile-android-v${mobile.version}`)
+  }
+
   if (dryRun) {
     console.log(`\n  would cut ${tag}`)
     console.log(`  since: ${previousTag ?? '(no previous tag)'}`)
     console.log(
+      `  mobile: ${
+        mobile
+          ? `${mobile.from} → ${mobile.version} (mobile-ios-v${mobile.version}, mobile-android-v${mobile.version})`
+          : `unchanged, upstream is not ahead of ${JSON.parse(readFileSync(path.join(root, 'mobile', 'app.json'), 'utf8')).expo.version}`
+      }`
+    )
+    console.log(
       `  notes: ${path.relative(root, notesPath)}${
         notesExist
           ? ' (already written)'
-          : ` (would draft from ${
-              draftReleaseNotes(version, previousTag)
+          : ` (${
+              draftReleaseNotes(commitsSincePreviousTag(previousTag), version, base)
                 .split('\n')
                 .filter((line) => line.startsWith('- ')).length
-            } commit subjects)`
+            } bullets)`
       }`
     )
     process.exit(0)
@@ -181,7 +264,7 @@ async function main() {
   const wroteDraft = !notesExist
   if (wroteDraft) {
     mkdirSync(path.dirname(notesPath), { recursive: true })
-    writeFileSync(notesPath, draftReleaseNotes(version, previousTag))
+    writeFileSync(notesPath, draftReleaseNotes(commitsSincePreviousTag(previousTag), version, base))
   }
   assertNoPrivateIdentifiers(notesPath)
 
@@ -199,30 +282,28 @@ async function main() {
     }
   )
 
-  git('add', 'package.json', 'resources/skills', path.relative(root, notesPath))
-  execFileSync(
-    'git',
-    ['-c', 'core.hooksPath=/dev/null', 'commit', '-q', '-m', `chore(release): cut ${version}`],
-    {
-      cwd: root
-    }
+  const toStage = ['package.json', 'resources/skills', path.relative(root, notesPath)]
+  if (mobile) {
+    bumpMobileVersion(upstream.mobile, { write: true })
+    toStage.push('mobile/app.json')
+  }
+  git('add', ...toStage)
+  const subject = mobile
+    ? `chore(release): cut ${version} and mobile ${mobile.version}`
+    : `chore(release): cut ${version}`
+  execFileSync('git', ['-c', 'core.hooksPath=/dev/null', 'commit', '-q', '-m', subject], {
+    cwd: root
+  })
+  console.log(`\n  ${git('rev-parse', '--short', 'HEAD')}  ${subject}`)
+  console.log(
+    `  notes: ${path.relative(root, notesPath)}${wroteDraft ? ' (drafted — read it)' : ''}`
   )
-  git('tag', tag)
-  console.log(`\n  ${tag} committed and tagged at ${git('rev-parse', '--short', 'HEAD')}`)
-  if (wroteDraft) {
-    console.log(
-      `  notes were drafted from commit subjects — read ${path.relative(root, notesPath)} and trim it`
-    )
-    console.log('  (amend the commit and re-tag with `git tag -f` if you edit them)')
-  }
-
-  if (flag('--push')) {
-    git('push', 'origin', 'main')
-    git('push', 'origin', tag)
-    console.log(`  pushed — fork-release.yml is building ${tag}`)
-  } else {
-    console.log(`\n  publish with:  git push origin main && git push origin ${tag}`)
-  }
+  const willTag = mobile
+    ? `${tag}, mobile-ios-v${mobile.version}, mobile-android-v${mobile.version}`
+    : tag
+  console.log(`\n  open a PR from ${branch}; merging it tags ${willTag} and builds`)
 }
 
-main().catch((error) => fail(error.message))
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => fail(error.message))
+}

--- a/config/scripts/cut-fork-release.test.mjs
+++ b/config/scripts/cut-fork-release.test.mjs
@@ -1,0 +1,77 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { highestRcForBase } from './release-rc-history.mjs'
+import { latestStableDesktopReleaseTag } from './latest-stable-release.mjs'
+
+/**
+ * The version rule the cut applies, stated once so a change to it fails here
+ * rather than on a published tag: follow upstream's newest stable base, never
+ * move the base backwards, and take the rc after the highest already cut.
+ */
+function nextVersion(upstreamBase, currentVersion, highestRc) {
+  const currentBase = currentVersion.split('-')[0]
+  const gt = (a, b) => {
+    const l = a.split('.').map(Number)
+    const r = b.split('.').map(Number)
+    for (let i = 0; i < 3; i += 1) {
+      if ((l[i] ?? 0) !== (r[i] ?? 0)) {
+        return (l[i] ?? 0) > (r[i] ?? 0)
+      }
+    }
+    return false
+  }
+  const base = gt(upstreamBase, currentBase) ? upstreamBase : currentBase
+  return `${base}-rc.${highestRc === null ? 0 : highestRc + 1}`
+}
+
+describe('fork release version', () => {
+  it('moves to upstream’s base and restarts the rc series', () => {
+    expect(nextVersion('1.4.196', '1.4.193-rc.0', null)).toBe('1.4.196-rc.0')
+  })
+
+  it('takes the next rc when the base has not moved', () => {
+    expect(nextVersion('1.4.193', '1.4.193-rc.0', 0)).toBe('1.4.193-rc.1')
+    expect(nextVersion('1.4.193', '1.4.193-rc.3', 3)).toBe('1.4.193-rc.4')
+  })
+
+  it('never moves the base backwards', () => {
+    // A fork-only fix can be cut ahead of upstream; the next sync must not
+    // renumber it downwards, which would make the update feed go back in time.
+    expect(nextVersion('1.4.190', '1.4.193-rc.1', 1)).toBe('1.4.193-rc.2')
+  })
+
+  it('reads the highest rc from history, not from package.json', () => {
+    // package.json is a working file and lies after a revert: the rc that was
+    // published still exists as a tag, and reusing its number would overwrite it.
+    const root = mkdtempSync(join(tmpdir(), 'cut-release-'))
+    const git = (...args) => execFileSync('git', args, { cwd: root, encoding: 'utf8' })
+    git('init', '-q')
+    git('config', 'user.email', 't@example.com')
+    git('config', 'user.name', 't')
+    mkdirSync(join(root, 'src'), { recursive: true })
+    writeFileSync(join(root, 'src', 'a.ts'), 'export const a = 1\n')
+    git('add', '.')
+    git('commit', '-q', '-m', 'first')
+    git('tag', 'v1.4.196-rc.0')
+    git('tag', 'v1.4.196-rc.1')
+
+    expect(highestRcForBase('1.4.196', { cwd: root })).toBe(1)
+    expect(nextVersion('1.4.196', '1.4.196-rc.0', highestRcForBase('1.4.196', { cwd: root }))).toBe(
+      '1.4.196-rc.2'
+    )
+  })
+
+  it('follows upstream’s stable releases, ignoring their prereleases', () => {
+    const releases = [
+      { tag_name: 'v1.4.197-rc.1' },
+      { tag_name: 'v1.4.196' },
+      { tag_name: 'mobile-android-v0.0.47' },
+      { tag_name: 'v1.4.195' }
+    ]
+    expect(latestStableDesktopReleaseTag(releases)).toBe('v1.4.196')
+  })
+})

--- a/config/scripts/cut-fork-release.test.mjs
+++ b/config/scripts/cut-fork-release.test.mjs
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest'
 
 import { highestRcForBase } from './release-rc-history.mjs'
 import { latestStableDesktopReleaseTag } from './latest-stable-release.mjs'
-import { upstreamMobileVersion } from './cut-fork-release.mjs'
+import { bumpMobileAppConfig, upstreamMobileVersion } from './cut-fork-release.mjs'
 import { draftReleaseNotes } from './release-notes-draft.mjs'
 
 /**
@@ -154,5 +154,50 @@ describe('release notes', () => {
       '1.4.196'
     )
     expect(notes).toContain('Fork-only changes; upstream is unchanged')
+  })
+})
+
+describe('mobile app config bump', () => {
+  // The shape that matters: a single-line array the repo's formatter keeps
+  // single-line. JSON.parse + JSON.stringify expands it to six lines, and
+  // app.json is a file upstream edits, so the noise returns as a sync conflict.
+  const config = [
+    '{',
+    '  "expo": {',
+    '    "name": "Manta",',
+    '    "version": "0.0.44",',
+    '    "ios": {',
+    '      "infoPlist": {',
+    '        "NSPrivacyAccessedAPITypeReasons": ["CA92.1"]',
+    '      }',
+    '    },',
+    '    "android": {',
+    '      "versionCode": 13',
+    '    }',
+    '  }',
+    '}',
+    ''
+  ].join('\n')
+
+  it('changes two lines and nothing else', () => {
+    const bumped = bumpMobileAppConfig(config, '0.0.47')
+    const changed = bumped.split('\n').filter((line, i) => line !== config.split('\n')[i])
+    expect(changed).toEqual(['    "version": "0.0.47",', '      "versionCode": 14'])
+    expect(bumped).toContain('"NSPrivacyAccessedAPITypeReasons": ["CA92.1"]')
+  })
+
+  it('counts versionCode up, never resetting it for a new version', () => {
+    // Android refuses to install an APK numbered below the one on the device.
+    expect(bumpMobileAppConfig(config, '1.0.0')).toContain('"versionCode": 14')
+  })
+
+  it('refuses a file where the field is not unique', () => {
+    // A plugin block carrying its own pinned version would otherwise get the
+    // app's version written into it, silently.
+    const ambiguous = config.replace(
+      '"name": "Manta",',
+      '"plugins": [["expo-build-properties", { "version": "1.2.3" }]],'
+    )
+    expect(() => bumpMobileAppConfig(ambiguous, '0.0.47')).toThrow(/matched 2 times/)
   })
 })

--- a/config/scripts/cut-fork-release.test.mjs
+++ b/config/scripts/cut-fork-release.test.mjs
@@ -6,6 +6,8 @@ import { describe, expect, it } from 'vitest'
 
 import { highestRcForBase } from './release-rc-history.mjs'
 import { latestStableDesktopReleaseTag } from './latest-stable-release.mjs'
+import { upstreamMobileVersion } from './cut-fork-release.mjs'
+import { draftReleaseNotes } from './release-notes-draft.mjs'
 
 /**
  * The version rule the cut applies, stated once so a change to it fails here
@@ -73,5 +75,84 @@ describe('fork release version', () => {
       { tag_name: 'v1.4.195' }
     ]
     expect(latestStableDesktopReleaseTag(releases)).toBe('v1.4.196')
+  })
+})
+
+describe('mobile release version', () => {
+  it('takes upstream’s newest mobile release, not the newest listed', () => {
+    const releases = [
+      { tag_name: 'v1.4.196' },
+      { tag_name: 'mobile-android-v0.0.9' },
+      { tag_name: 'mobile-android-v0.0.47' },
+      { tag_name: 'mobile-android-v0.0.46' },
+      { tag_name: 'mobile-ios-v0.0.48' }
+    ]
+    // 0.0.9 sorts above 0.0.47 as a string, and iOS ships to TestFlight without
+    // a GitHub release, so only the Android tags name a version that has shipped.
+    expect(upstreamMobileVersion(releases)).toBe('0.0.47')
+  })
+
+  it('is null when upstream has published no mobile release', () => {
+    expect(upstreamMobileVersion([{ tag_name: 'v1.4.196' }])).toBe(null)
+  })
+})
+
+describe('release notes', () => {
+  const up = (subject) => ({ subject, upstream: true })
+  const fork = (subject) => ({ subject, upstream: false })
+  const subjects = [
+    up('fix(ssh): reconnect after the relay drops (#101)'),
+    up('fix(ssh): keep the host verdict when contact is lost'),
+    up('fix(terminal): stop eating the last line'),
+    up('feat(browser): open links in the built-in browser'),
+    fork('sync: 120 upstream commits (#14)'),
+    fork('chore(release): cut 1.4.195-rc.0'),
+    fork('feat(sync): refresh patch hashes in finish'),
+    up('docs: tidy the readme'),
+    up('not a conventional commit')
+  ]
+
+  it('names the biggest subsystems and lists features', () => {
+    expect(draftReleaseNotes(subjects, '1.4.196-rc.0', '1.4.196')).toBe(
+      [
+        '# 1.4.196-rc.0',
+        '',
+        "Picks up upstream's work through v1.4.196.",
+        '',
+        '- SSH and remote hosts — 2 fixes',
+        '- Terminal — 1 fix',
+        '- New: open links in the built-in browser',
+        ''
+      ].join('\n')
+    )
+  })
+
+  it('carries no personal identifiers from commit subjects it drops', () => {
+    const notes = draftReleaseNotes(subjects, '1.4.196-rc.0', '1.4.196')
+    expect(notes).not.toMatch(/#\d+/)
+    expect(notes.split('\n').filter((line) => line.startsWith('- ')).length).toBeLessThanOrEqual(8)
+  })
+
+  it('leaves the fork’s own sync plumbing out of the news', () => {
+    // `feat(sync): …` is this fork's tooling. Announcing it as a feature of the
+    // release tells a user about work that changed nothing they can see.
+    const notes = draftReleaseNotes(subjects, '1.4.196-rc.0', '1.4.196')
+    expect(notes).not.toContain('patch hashes')
+    expect(notes).not.toContain('120 upstream commits')
+  })
+
+  it('falls back to a count when nothing is scoped', () => {
+    expect(
+      draftReleaseNotes([up('fix: something'), up('chore: other')], '1.0.0-rc.0', '1.0.0')
+    ).toContain('- 2 changes')
+  })
+
+  it('says so when a release carries no upstream work', () => {
+    const notes = draftReleaseNotes(
+      [fork('fix(ci): the stub CLI must name the packaged skill')],
+      '1.4.196-rc.1',
+      '1.4.196'
+    )
+    expect(notes).toContain('Fork-only changes; upstream is unchanged')
   })
 })

--- a/config/scripts/pending-release-tags.mjs
+++ b/config/scripts/pending-release-tags.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Which release tags the commit on main is missing.
+ *
+ * `auto-release.yml` runs this on every push to main and pushes what it names.
+ * The question it answers is narrow on purpose: not "is there a version without
+ * a tag" but "did this push change a version". A repository can legitimately sit
+ * at an untagged version — a revert, a hand-edited manifest, the mobile app
+ * before this fork ever shipped one — and none of those are a release. Only a
+ * merged `chore(release):` commit is, and what makes it one is that it moved
+ * `package.json` or `mobile/app.json`.
+ *
+ * Writes `tags=<space separated>` to $GITHUB_OUTPUT; an empty value means the
+ * push was an ordinary change and nothing should be built.
+ */
+import { execFileSync } from 'node:child_process'
+import { appendFileSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { pathToFileURL } from 'node:url'
+
+const DESKTOP_VERSION = /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
+const MOBILE_VERSION = /^[0-9]+\.[0-9]+\.[0-9]+$/
+
+/**
+ * @param versions {{ desktop, previousDesktop, mobile, previousMobile }} — a
+ *   `previous` of null means the file could not be read at the earlier commit,
+ *   which is treated as changed: a first push should tag, not stay silent.
+ * @param hasTag (name) => boolean
+ */
+export function pendingReleaseTags(versions, hasTag) {
+  const tags = []
+  const { desktop, previousDesktop, mobile, previousMobile } = versions
+
+  if (desktop !== previousDesktop) {
+    if (!DESKTOP_VERSION.test(desktop)) {
+      throw new Error(`package.json version ${desktop} is not X.Y.Z or X.Y.Z-rc.N`)
+    }
+    if (!hasTag(`v${desktop}`)) {
+      tags.push(`v${desktop}`)
+    }
+  }
+
+  if (mobile !== previousMobile) {
+    if (!MOBILE_VERSION.test(mobile)) {
+      throw new Error(`mobile/app.json version ${mobile} is not X.Y.Z`)
+    }
+    // Both platforms read the same marketing version out of mobile/app.json;
+    // they have separate tags only so App Store review cannot hold up Android.
+    for (const name of [`mobile-ios-v${mobile}`, `mobile-android-v${mobile}`]) {
+      if (!hasTag(name)) {
+        tags.push(name)
+      }
+    }
+  }
+
+  return tags
+}
+
+function main() {
+  const root = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim()
+  const git = (...args) => execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim()
+
+  const before = process.env.BEFORE ?? ''
+  // A dispatch has no before-SHA and a first push reports all zeroes.
+  const baseline = /^0*$/.test(before) || before === '' ? 'HEAD^' : before
+
+  const readVersion = (file, pick, ref) => {
+    const text =
+      ref === null ? readFileSync(path.join(root, file), 'utf8') : git('show', `${ref}:${file}`)
+    return pick(JSON.parse(text))
+  }
+  const atBaseline = (file, pick) => {
+    try {
+      return readVersion(file, pick, baseline)
+    } catch {
+      return null
+    }
+  }
+
+  const desktopOf = (json) => String(json.version)
+  const mobileOf = (json) => String(json.expo.version)
+  const versions = {
+    desktop: readVersion('package.json', desktopOf, null),
+    previousDesktop: atBaseline('package.json', desktopOf),
+    mobile: readVersion('mobile/app.json', mobileOf, null),
+    previousMobile: atBaseline('mobile/app.json', mobileOf)
+  }
+
+  const tags = pendingReleaseTags(versions, (name) => git('tag', '--list', name) !== '')
+  console.log(
+    `desktop ${versions.previousDesktop ?? '?'} → ${versions.desktop} · ` +
+      `mobile ${versions.previousMobile ?? '?'} → ${versions.mobile}`
+  )
+  console.log(tags.length > 0 ? `pending: ${tags.join(' ')}` : 'pending: none')
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `tags=${tags.join(' ')}\n`)
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main()
+  } catch (error) {
+    console.error(`✗ ${error.message}`)
+    process.exit(1)
+  }
+}

--- a/config/scripts/pending-release-tags.mjs
+++ b/config/scripts/pending-release-tags.mjs
@@ -87,7 +87,12 @@ function main() {
     previousMobile: atBaseline('mobile/app.json', mobileOf)
   }
 
-  const tags = pendingReleaseTags(versions, (name) => git('tag', '--list', name) !== '')
+  // origin, not the local tag list: a developer clone fetches upstream, so
+  // upstream's own mobile-android-v* tags live there — and this fork follows
+  // upstream's mobile version, so every mobile tag it cuts shares a name with
+  // one of them. What decides the question is whether the tag is published here.
+  const published = (name) => git('ls-remote', '--tags', 'origin', name) !== ''
+  const tags = pendingReleaseTags(versions, published)
   console.log(
     `desktop ${versions.previousDesktop ?? '?'} → ${versions.desktop} · ` +
       `mobile ${versions.previousMobile ?? '?'} → ${versions.mobile}`

--- a/config/scripts/pending-release-tags.test.mjs
+++ b/config/scripts/pending-release-tags.test.mjs
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import { pendingReleaseTags } from './pending-release-tags.mjs'
+
+const none = () => false
+const all = () => true
+
+describe('pending release tags', () => {
+  const steady = {
+    desktop: '1.4.196-rc.0',
+    previousDesktop: '1.4.196-rc.0',
+    mobile: '0.0.44',
+    previousMobile: '0.0.44'
+  }
+
+  it('tags nothing when a push changed no version', () => {
+    // The common case by far: an ordinary PR merging into main.
+    expect(pendingReleaseTags(steady, none)).toEqual([])
+  })
+
+  it('does not tag an untagged version the push did not touch', () => {
+    // The fork sat at mobile 0.0.44 for months without ever shipping a mobile
+    // release. Standing still is not a release, and tagging one on the next
+    // unrelated merge would ship a build nobody asked for.
+    expect(pendingReleaseTags(steady, none)).toEqual([])
+  })
+
+  it('tags the desktop release when package.json moved', () => {
+    expect(pendingReleaseTags({ ...steady, previousDesktop: '1.4.193-rc.0' }, none)).toEqual([
+      'v1.4.196-rc.0'
+    ])
+  })
+
+  it('tags both mobile platforms from the one version they share', () => {
+    expect(pendingReleaseTags({ ...steady, previousMobile: '0.0.43' }, none)).toEqual([
+      'mobile-ios-v0.0.44',
+      'mobile-android-v0.0.44'
+    ])
+  })
+
+  it('tags desktop and mobile together when a sync moved both', () => {
+    expect(
+      pendingReleaseTags(
+        {
+          desktop: '1.4.196-rc.0',
+          previousDesktop: '1.4.193-rc.0',
+          mobile: '0.0.47',
+          previousMobile: '0.0.44'
+        },
+        none
+      )
+    ).toEqual(['v1.4.196-rc.0', 'mobile-ios-v0.0.47', 'mobile-android-v0.0.47'])
+  })
+
+  it('skips a tag that already exists', () => {
+    // A re-run of the workflow, or a tag pushed by hand before the job caught up.
+    expect(pendingReleaseTags({ ...steady, previousDesktop: '1.4.193-rc.0' }, all)).toEqual([])
+  })
+
+  it('tags one mobile platform when only the other is already tagged', () => {
+    const tagged = (name) => name === 'mobile-ios-v0.0.44'
+    expect(pendingReleaseTags({ ...steady, previousMobile: '0.0.43' }, tagged)).toEqual([
+      'mobile-android-v0.0.44'
+    ])
+  })
+
+  it('treats an unreadable baseline as changed', () => {
+    // First push, or a shallow fetch: silence would mean a release never ships.
+    expect(
+      pendingReleaseTags({ ...steady, previousDesktop: null, previousMobile: null }, none)
+    ).toEqual(['v1.4.196-rc.0', 'mobile-ios-v0.0.44', 'mobile-android-v0.0.44'])
+  })
+
+  it('refuses a version that is not release-shaped', () => {
+    // A hand-edited manifest must not become the tag electron-updater compares.
+    expect(() =>
+      pendingReleaseTags(
+        { ...steady, desktop: '1.4.196-beta', previousDesktop: '1.4.193-rc.0' },
+        none
+      )
+    ).toThrow(/not X\.Y\.Z/)
+    expect(() =>
+      pendingReleaseTags({ ...steady, mobile: '0.0.44-rc.1', previousMobile: '0.0.43' }, none)
+    ).toThrow(/not X\.Y\.Z/)
+  })
+})

--- a/config/scripts/release-notes-draft.mjs
+++ b/config/scripts/release-notes-draft.mjs
@@ -1,0 +1,96 @@
+/**
+ * A few lines saying what upstream changed, not a changelog.
+ *
+ * Release notes become the GitHub Release body and the in-app update card, so
+ * they are read by someone deciding whether to install — a title, a sentence and
+ * a handful of bullets. Rationale, tradeoffs and implementation stay in the
+ * commits, which is where someone looking for them will go.
+ */
+
+// A conventional-commit scope names a subsystem; these are the ones worth
+// naming in a release note, in the words a user would recognise.
+const SCOPE_LABELS = new Map([
+  ['ssh', 'SSH and remote hosts'],
+  ['relay', 'Relay'],
+  ['terminal', 'Terminal'],
+  ['pty', 'Terminal'],
+  ['native-chat', 'Native chat'],
+  ['chat', 'Chat'],
+  ['browser', 'Built-in browser'],
+  ['git', 'Git'],
+  ['worktree', 'Worktrees'],
+  ['worktrees', 'Worktrees'],
+  ['mobile', 'Mobile app'],
+  ['updater', 'Updates'],
+  ['win', 'Windows'],
+  ['windows', 'Windows'],
+  ['linux', 'Linux'],
+  ['macos', 'macOS'],
+  ['i18n', 'Localization'],
+  ['editor', 'Editor'],
+  ['skills', 'Skills'],
+  ['runtime', 'Runtime'],
+  ['startup', 'Startup'],
+  ['codex', 'Codex'],
+  ['claude', 'Claude']
+])
+
+const CONVENTIONAL = /^([a-z]+)(?:\(([^)]+)\))?!?:\s*(.+)$/i
+// The fork's own sync bookkeeping is not news to anyone installing this.
+const FORK_BOOKKEEPING = /^(sync|chore\(release\)|chore\(sync\))[:(]/i
+
+/**
+ * @param entries [{ subject, upstream }] — commits since the previous release.
+ *   `upstream` comes from the `Mirror-Of:` trailer the mirror stamps on every
+ *   commit it replays, which is the only reliable way to tell upstream's work
+ *   from the fork's: both use conventional commits, and the fork's own sync
+ *   plumbing lands as `feat(sync)` and would otherwise be announced as news.
+ * @param version the version being cut, e.g. 1.4.196-rc.0
+ * @param upstreamBase upstream's stable release this picks up, e.g. 1.4.196
+ */
+export function draftReleaseNotes(entries, version, upstreamBase) {
+  const usable = entries.filter((entry) => entry?.subject && !FORK_BOOKKEEPING.test(entry.subject))
+  const fromUpstream = usable.filter((entry) => entry.upstream)
+  // A release with no upstream commits is a fork-only fix; it still needs notes.
+  const commits = fromUpstream.length > 0 ? fromUpstream : usable
+  const lede =
+    fromUpstream.length > 0
+      ? `Picks up upstream's work through v${upstreamBase}.`
+      : 'Fork-only changes; upstream is unchanged since the last release.'
+
+  const fixesByLabel = new Map()
+  const features = []
+  for (const { subject } of commits) {
+    const parsed = CONVENTIONAL.exec(subject)
+    if (!parsed) {
+      continue
+    }
+    const [, rawType, scope, rest] = parsed
+    const type = rawType.toLowerCase()
+    if (type === 'feat') {
+      features.push(rest.replace(/\s*\(#\d+\)\s*$/, ''))
+      continue
+    }
+    if (!['fix', 'perf', 'refactor'].includes(type)) {
+      continue
+    }
+    // A scope can be a path like `ssh/relay`; the first segment names the subsystem.
+    const label = SCOPE_LABELS.get((scope ?? '').split('/')[0].toLowerCase())
+    if (label) {
+      fixesByLabel.set(label, (fixesByLabel.get(label) ?? 0) + 1)
+    }
+  }
+
+  const bullets = [...fixesByLabel.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 5)
+    .map(([label, count]) => `- ${label} \u2014 ${count} ${count === 1 ? 'fix' : 'fixes'}`)
+  for (const feature of features.slice(0, 3)) {
+    bullets.push(`- New: ${feature}`)
+  }
+  if (bullets.length === 0) {
+    bullets.push(`- ${commits.length} ${commits.length === 1 ? 'change' : 'changes'}`)
+  }
+
+  return [`# ${version}`, '', lede, '', ...bullets, ''].join('\n')
+}

--- a/config/scripts/required-checks-contract.test.mjs
+++ b/config/scripts/required-checks-contract.test.mjs
@@ -1,0 +1,58 @@
+/**
+ * Branch protection on main requires `verify` and `Mobile Checks`. This pins the
+ * two ways that arrangement breaks without anyone noticing until a pull request
+ * refuses to merge.
+ */
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+const workflowsDir = resolve(import.meta.dirname, '../../.github/workflows')
+const workflows = readdirSync(workflowsDir)
+  .filter((file) => file.endsWith('.yml'))
+  .map((file) => ({ file, parsed: parse(readFileSync(join(workflowsDir, file), 'utf8')) }))
+
+// `on:` parses as the boolean true — YAML 1.1, which the Actions parser is not.
+const triggers = (parsed) => parsed.on ?? parsed[true]
+
+/** Every job whose check-run name is `name`, across all workflows. */
+const jobsNamed = (name) =>
+  workflows.flatMap(({ file, parsed }) =>
+    Object.entries(parsed.jobs ?? {})
+      .filter(([id, job]) => (job.name ?? id) === name)
+      .map(([id, job]) => ({ file, id, job }))
+  )
+
+const REQUIRED = ['verify', 'Mobile Checks']
+
+describe('required status checks', () => {
+  it.each(REQUIRED)('%s is reported on every pull request', (name) => {
+    // A workflow skipped by a `paths:` filter creates no check run at all, so a
+    // pull request that misses those paths waits forever on a context that will
+    // never appear. `Mobile Checks` was filtered that way and blocked a release
+    // PR that touched no mobile file. Filtering has to happen at the job, with
+    // an `if:` — a job skipped that way still reports, and counts as passing.
+    const jobs = jobsNamed(name)
+    expect(jobs.length, `no job produces the required check ${name}`).toBeGreaterThan(0)
+    for (const { file, parsed } of jobs.map((entry) => ({
+      ...entry,
+      parsed: workflows.find((w) => w.file === entry.file).parsed
+    }))) {
+      const pullRequest = triggers(parsed)?.pull_request
+      expect(pullRequest, `${file} does not run on pull_request`).toBeDefined()
+      expect(pullRequest?.paths, `${file} filters ${name} at the trigger`).toBeUndefined()
+      expect(
+        pullRequest?.['paths-ignore'],
+        `${file} filters ${name} at the trigger`
+      ).toBeUndefined()
+    }
+  })
+
+  it.each(REQUIRED)('%s is produced by exactly one job', (name) => {
+    // Two jobs sharing a check name are one context to branch protection, and
+    // the red one hides behind the green one. pr.yml's gate and mobile.yml's job
+    // were both `verify` until mobile's was given a display name.
+    expect(jobsNamed(name).map(({ file, id }) => `${file}:${id}`)).toHaveLength(1)
+  })
+})

--- a/docs/reference/fork-release-automation.md
+++ b/docs/reference/fork-release-automation.md
@@ -1,0 +1,107 @@
+# Cutting and publishing a fork release
+
+Upstream ships `1.4.196`; this fork ships `1.4.196-rc.N` once it has merged that
+work. The mobile app has its own line — upstream ships `mobile-android-v0.0.47`,
+this fork follows to `0.0.47`. Neither happens on its own, and a sync that lands
+without a release is upstream's fixes sitting in a branch nobody can install.
+
+## The path
+
+```
+sync branch ──► chore(release): cut …  ──► PR ──► main ──► auto-release.yml ──► tags ──► builds
+   sync-run.sh      cut-fork-release.mjs    verify +          pending-release-tags   fork-release.yml
+                                          Mobile Checks                             mobile-*-release.yml
+```
+
+One PR carries both the sync and the release. Merging it is what publishes.
+
+### 1. Cut — `config/scripts/cut-fork-release.mjs`
+
+Run on a branch, never on main. It picks the version, drafts the notes, bumps
+`package.json` and `mobile/app.json`, seals the skill bundle manifest for that
+version, and commits. It does **not** tag.
+
+The version rule, pinned by `cut-fork-release.test.mjs`:
+
+- The base is upstream's newest stable `vX.Y.Z` release, or the fork's current
+  base if that is higher — it never moves backwards, because an update feed that
+  goes back in time offers the same update forever.
+- The rc number is one above the highest already cut for that base, read from
+  tags and release subjects rather than from `package.json`, which is a working
+  file and lies after a revert.
+- Mobile moves only when upstream's newest `mobile-android-v*` is ahead of
+  `mobile/app.json`. `versionCode` goes up by one; Android refuses to install an
+  APK numbered below the one on the device, and
+  `mobile/scripts/prepare-android-release.mjs` rejects a tag that disagrees with
+  the committed version, so the bump has to be in the commit.
+
+`--dry-run` reports what it would do and writes nothing. `--version X.Y.Z-rc.N`
+overrides the computed version.
+
+### 2. Merge
+
+The release commit goes through a PR because main requires `verify` and
+`Mobile Checks`. That is not a detour — it means every tag points at a commit
+those checks passed.
+
+### 3. Tag — `.github/workflows/auto-release.yml`
+
+Runs on every push to main. `config/scripts/pending-release-tags.mjs` asks a
+narrow question: *did this push change a version*. Not "is there a version
+without a tag" — the fork sat at mobile `0.0.44` for months without shipping a
+mobile release, and a revert or a hand-edited manifest is not a release either.
+Only a version that moved gets a tag.
+
+It then pushes `v<version>`, and `mobile-ios-v<v>` / `mobile-android-v<v>` when
+mobile moved. Each tag raises its own create event, so each starts its own build.
+
+## The one credential
+
+The job cannot push the tags with its own `GITHUB_TOKEN`: a push made with it
+deliberately creates no events, so the tag would land and nothing would build.
+It pushes over SSH with a write deploy key instead — a separate credential, so
+its push is a real push event.
+
+There is no way around this. Calling `fork-release.yml` as a reusable workflow
+was the obvious alternative and it does not work: its macOS leg runs in the
+`apple-signing` environment, whose deployment policy admits `v*` tags and nothing
+else, so a run started from main would build for forty minutes and then die at
+the environment gate having published nothing.
+
+Set it up once:
+
+```sh
+REPO=<owner>/<repo>
+ssh-keygen -t ed25519 -N '' -C manta-release-tagger -f ./release_key
+gh api "repos/$REPO/keys" -f title='release-tagger (auto-release.yml)' \
+  -f key="$(cat ./release_key.pub)" -F read_only=false
+gh secret set RELEASE_TAGGER_KEY --repo "$REPO" < ./release_key
+rm ./release_key ./release_key.pub
+```
+
+Until the secret exists the job reports what it would have tagged and stops
+green — a missing credential is a setup gap, not a broken build. Tag by hand in
+the meantime:
+
+```sh
+git push origin v1.4.196-rc.0
+```
+
+Revoke by deleting the deploy key (`gh api -X DELETE repos/$REPO/keys/<id>`) and
+the secret; nothing else depends on it.
+
+## Release notes
+
+`config/scripts/release-notes-draft.mjs` writes
+`docs/release-notes/<version>.md`: a title, one sentence naming the upstream
+release this picks up, and a handful of bullets grouped by conventional-commit
+scope, plus any features by name. Rationale, tradeoffs and implementation stay in
+the commits, which is where someone looking for them will go.
+
+The draft is a draft — read it and trim it before the PR merges.
+
+`cut-fork-release.mjs` refuses to commit notes carrying a personal identifier:
+the maintainer's name or account, the Apple Team ID, the relay domain, an IP
+address. Release notes become the public GitHub Release body and the in-app
+update card. When install instructions are needed, point at the README rather
+than writing an account name into the notes.


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​437 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​437 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​840 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​830 |

<!-- /manta-pr-loc -->

A sync that lands without a release is upstream's fixes sitting in a branch. This
makes the release happen on its own, on both platforms, with notes someone can
read.

## The path

```
sync branch ──► chore(release): cut …  ──► PR ──► main ──► auto-release.yml ──► tags ──► builds
   sync-finish.sh   cut-fork-release.mjs    verify +         pending-release-tags   fork-release.yml
                                          Mobile Checks                            mobile-*-release.yml
```

One PR carries the sync and the release. Merging it is what publishes.

## Release notes are a few bullets now

Grouped by conventional-commit scope, built **only** from commits carrying the
mirror's `Mirror-Of:` trailer — without that split this fork's own sync plumbing
lands as `feat(sync): …` and gets announced as release news. Real output for the
range this branch is sitting on:

```
# 1.4.196-rc.0

Picks up upstream's work through v1.4.196.

- SSH and remote hosts — 30 fixes
- Worktrees — 24 fixes
- Terminal — 23 fixes
- Native chat — 18 fixes
- Relay — 15 fixes
- New: host-stamped remote foreground identity
- New: unify local agent entrypoint routing
- New: dispatch git and filesystem providers by execution host
```

## Mobile ships too

This fork has never published a mobile release; upstream is at
`mobile-android-v0.0.47` and `mobile/app.json` said `0.0.44`. The cut now moves
it, advances `versionCode`, and tags both platforms. The bump has to be in the
commit — `prepare-android-release.mjs` rejects a tag that disagrees with the
committed version, and both platforms read that one field.

## Two constraints that shaped this

**A tag pushed with `GITHUB_TOKEN` triggers nothing.** GitHub suppresses events
from it to prevent recursion, so the tag would land and no build would start.
`auto-release.yml` pushes over SSH with a write deploy key instead.

Calling `fork-release.yml` as a reusable workflow was the obvious way to avoid a
credential, and it does not work: its macOS leg runs in the `apple-signing`
environment, whose deployment policy admits `v*` tags and nothing else, so a run
started from main would build for forty minutes and then die at the environment
gate having published nothing. The workflow's own comments already warned about
exactly this.

**main requires `verify` and `Mobile Checks`,** so a freshly made commit cannot
be pushed to it at all. The release commit travels through a PR like everything
else, which means every tag points at a commit those checks passed.

`RELEASE_TAGGER_KEY` and its deploy key are configured. Without them the job
reports what it would have tagged and stops green — a setup gap is not a broken
build.

## Three bugs a smoke run caught

All invisible to unit tests, because all three are about the repository this runs
in:

- **Tag freedom was read from the local tag list.** A developer clone fetches
  upstream, so upstream's 22 `mobile-android-v*` tags live in it — and this fork
  follows upstream's mobile version, so every mobile tag it cuts shares a name
  with one of them and no fork tag at all. The cut refused to run;
  `pending-release-tags.mjs` silently dropped Android and would have shipped iOS
  alone. Both ask origin now.
- **`mobile/app.json` was rewritten with `JSON.stringify`,** which reflowed it —
  nineteen lines of noise around a two-line change, in a file upstream edits, so
  it would have come back as a merge conflict on every sync. Two guarded
  substitutions now.
- **A NUL separator in `execFile` argv,** which Node refuses outright.

## Verification

- 30 unit + contract tests across the version rule, the notes, the tag decision,
  and the coupling between the emitted tag names and the three release workflows'
  triggers — the last one being what breaks silently if a trigger is ever
  narrowed.
- `config/scripts` full suite: 1365 passing.
- The real cut run end to end in a throwaway worktree: correct version, 2-line
  `app.json` diff, all three tags pending.

https://claude.ai/code/session_013K4DZ2kn4GTKEqLsagKYdj
