### PR TITLE
chore(release): 1.4.196-rc.0 and mobile 0.0.47

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -47,7 +47,7 @@ jobs:
     if: github.repository == 'paidaxingyo666/Manta'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/config/scripts/release-notes-draft.mjs
+++ b/config/scripts/release-notes-draft.mjs
@@ -83,9 +83,11 @@ export function draftReleaseNotes(entries, version, upstreamBase) {
 
   const bullets = [...fixesByLabel.entries()]
     .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
-    .slice(0, 5)
+    .slice(0, 4)
     .map(([label, count]) => `- ${label} \u2014 ${count} ${count === 1 ? 'fix' : 'fixes'}`)
-  for (const feature of features.slice(0, 3)) {
+  // Six bullets is the ceiling, not a target: a release note is read by someone
+  // deciding whether to install, and a sixth line has never changed that answer.
+  for (const feature of features.slice(0, 2)) {
     bullets.push(`- New: ${feature}`)
   }
   if (bullets.length === 0) {

--- a/docs/release-notes/1.4.196-rc.0.md
+++ b/docs/release-notes/1.4.196-rc.0.md
@@ -1,0 +1,12 @@
+# 1.4.196-rc.0
+
+Picks up upstream's work through v1.4.196.
+
+- SSH and remote hosts — 30 fixes
+- Worktrees — 24 fixes
+- Terminal — 23 fixes
+- Native chat — 18 fixes
+- Relay — 15 fixes
+- New: host-stamped remote foreground identity
+- New: unify local agent entrypoint routing
+- New: dispatch git and filesystem providers by execution host

--- a/docs/release-notes/1.4.196-rc.0.md
+++ b/docs/release-notes/1.4.196-rc.0.md
@@ -6,7 +6,5 @@ Picks up upstream's work through v1.4.196.
 - Worktrees — 24 fixes
 - Terminal — 23 fixes
 - Native chat — 18 fixes
-- Relay — 15 fixes
 - New: host-stamped remote foreground identity
 - New: unify local agent entrypoint routing
-- New: dispatch git and filesystem providers by execution host

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Manta",
     "slug": "manta-mobile",
-    "version": "0.0.44",
+    "version": "0.0.47",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -78,7 +78,7 @@
       "allowBackup": false,
       "permissions": ["RECORD_AUDIO", "MODIFY_AUDIO_SETTINGS"],
       "package": "cn.sh.manta.mobile",
-      "versionCode": 13
+      "versionCode": 14
     },
     "plugins": [
       "expo-router",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta",
-  "version": "1.4.193-rc.0",
+  "version": "1.4.196-rc.0",
   "description": "Next-gen IDE for parallel agentic development",
   "homepage": "https://github.com/paidaxingyo666/Manta",
   "author": "Manta",

--- a/resources/skills/release-mapping.json
+++ b/resources/skills/release-mapping.json
@@ -652,6 +652,19 @@
         "manta-per-workspace-env": 6,
         "orchestration": 29
       }
+    },
+    {
+      "appVersion": "1.4.196-rc.0",
+      "skills": {
+        "computer-use": 10,
+        "linear-tickets": 11,
+        "manta-cli": 38,
+        "manta-emulator": 8,
+        "manta-emulator-android": 6,
+        "manta-linear": 9,
+        "manta-per-workspace-env": 6,
+        "orchestration": 30
+      }
     }
   ]
 }


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 |

<!-- /manta-pr-loc -->

The first release cut by the automation, and this fork's first mobile release
ever.

Merging this publishes: `auto-release.yml` tags `v1.4.196-rc.0`,
`mobile-ios-v0.0.47` and `mobile-android-v0.0.47`, and each tag starts its build.

## What ships

```
# 1.4.196-rc.0

Picks up upstream's work through v1.4.196.

- SSH and remote hosts — 30 fixes
- Worktrees — 24 fixes
- Terminal — 23 fixes
- Native chat — 18 fixes
- New: host-stamped remote foreground identity
- New: unify local agent entrypoint routing
```

Everything upstream shipped between v1.4.193 and v1.4.196, merged by syncs #13
and #14. Desktop goes from 1.4.193-rc.0; mobile from 0.0.44, which was never
published, to upstream's 0.0.47.

## Also here

- `auto-release.yml` moves to `actions/checkout@v6`. v4 targets Node 20, which
  the runners now force onto 24 with a deprecation warning; every other workflow
  here was already on v6.
- The notes draft stops at four fix groups and two features. Six bullets is a
  ceiling, not a target.

## Checked before cutting

- All six iOS signing secrets are present; Android needs none. This is the first
  time either mobile workflow will run on this fork.
- `auto-release.yml`'s first live run, on the merge of #15, correctly reported
  `pending: none` — no version had moved, so it tagged nothing.

https://claude.ai/code/session_013K4DZ2kn4GTKEqLsagKYdj