### PR TITLE
fix(package): read the package's arch, not the output directory's — and cut 1.4.196-rc.1

### DIFF
--- a/config/scripts/cut-fork-release.mjs
+++ b/config/scripts/cut-fork-release.mjs
@@ -119,17 +119,54 @@ export function upstreamMobileVersion(releases) {
   return versions.at(-1) ?? null
 }
 
+function githubToken() {
+  const fromEnv = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN
+  if (fromEnv) {
+    return fromEnv
+  }
+  try {
+    return execFileSync('gh', ['auth', 'token'], { encoding: 'utf8' }).trim()
+  } catch {
+    return fail('no GitHub token: set GITHUB_TOKEN or run `gh auth login`')
+  }
+}
+
+/** This fork's own repo; `gh repo view` answers upstream when an upstream remote exists. */
+function forkRepo() {
+  const url = git('remote', 'get-url', 'origin')
+  return /[:/]([^/:]+\/[^/]+?)(?:\.git)?$/.exec(url)?.[1] ?? null
+}
+
+/** The newest release this fork actually published, as a tag name. */
+async function newestPublishedTag() {
+  const repo = forkRepo()
+  if (!repo) {
+    return null
+  }
+  try {
+    const releases = await fetchReleases(repo, githubToken())
+    return (
+      releases
+        .filter((release) => release.draft !== true && typeof release.tag_name === 'string')
+        .map((release) => /^v([0-9]+\.[0-9]+\.[0-9]+)(?:-rc\.([0-9]+))?$/.exec(release.tag_name))
+        .filter(Boolean)
+        // A stable X.Y.Z outranks every X.Y.Z-rc.N, which is what Infinity says.
+        .sort(
+          (a, b) =>
+            compareBases(a[1], b[1]) ||
+            (a[2] === undefined ? Infinity : Number(a[2])) -
+              (b[2] === undefined ? Infinity : Number(b[2]))
+        )
+        .at(-1)?.[0] ?? null
+    )
+  } catch {
+    return null
+  }
+}
+
 /** Upstream's newest shipped release, which is the line this fork's version follows. */
 async function upstreamStableBase() {
-  let token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN
-  if (!token) {
-    try {
-      token = execFileSync('gh', ['auth', 'token'], { encoding: 'utf8' }).trim()
-    } catch {
-      fail('no GitHub token: set GITHUB_TOKEN or run `gh auth login`')
-    }
-  }
-  const releases = await fetchReleases(UPSTREAM_REPO, token)
+  const releases = await fetchReleases(UPSTREAM_REPO, githubToken())
   const tag = latestStableDesktopReleaseTag(releases)
   if (!tag) {
     fail(`${UPSTREAM_REPO} has no stable vX.Y.Z release`)
@@ -263,11 +300,18 @@ async function main() {
   const tag = `v${version}`
   assertTagIsFree(tag)
 
-  // Not `--merged HEAD`: the 2026-09-02 cutover put main on a generated mirror
-  // of upstream, so every tag cut before it is reachable only from main-legacy.
-  // Newest by version is what "since the last release" means here regardless.
+  // The newest *published* release, not the newest tag. A tag whose build failed
+  // published nothing, so a reader of these notes is coming from the release
+  // before it and needs what that one missed: rc.0's arm64 leg failed, and
+  // rc.1's draft read "2 changes" — true of the tag range and useless to them.
+  //
+  // Not `--merged HEAD` for the fallback either: the 2026-09-02 cutover put main
+  // on a generated mirror of upstream, so every tag cut before it is reachable
+  // only from main-legacy.
   const previousTag =
-    git('tag', '--list', 'v*', '--sort=-v:refname').split('\n').find(Boolean) ?? null
+    (await newestPublishedTag()) ??
+    git('tag', '--list', 'v*', '--sort=-v:refname').split('\n').find(Boolean) ??
+    null
   const notesPath = path.join(root, 'docs', 'release-notes', `${version}.md`)
   const notesExist = existsSync(notesPath)
 

--- a/config/scripts/cut-fork-release.mjs
+++ b/config/scripts/cut-fork-release.mjs
@@ -212,7 +212,18 @@ async function main() {
   if (git('status', '--porcelain', '--untracked-files=no')) {
     fail('working tree is not clean')
   }
-  git('fetch', '--quiet', 'origin', 'main')
+  // The release tags as well as main: auto-release.yml creates them now, so a
+  // clone that has only ever pulled branches has none of them, and
+  // highestRcForBase reads the local list — the cut recomputed an rc that had
+  // already shipped, caught by the origin check below but only after the work.
+  //
+  // This refspec and not --tags: this clone also fetches upstream, whose mobile
+  // tags share their names with the fork's, so --tags aborts the whole fetch on
+  // "would clobber existing tag". `v*` reaches only the desktop release tags,
+  // and every one origin holds is a `-rc.N` this fork cut — upstream's plain
+  // `vX.Y.Z` tags live in this clone but were never pushed here, so none is in
+  // range. (A refspec allows one `*` per side, so `v*-rc.*` is not expressible.)
+  git('fetch', '--quiet', 'origin', 'main', '+refs/tags/v*:refs/tags/v*')
   // Cutting from a branch that is behind main would compute the version from a
   // stale upstream base and write notes missing whatever landed in between.
   try {

--- a/config/scripts/verify-linux-glibc-floor.cjs
+++ b/config/scripts/verify-linux-glibc-floor.cjs
@@ -209,10 +209,18 @@ const ARCH_BY_TOKEN = Object.freeze({ arm64: 'arm64', aarch64: 'arm64', x64: 'x6
  * Why this matters: some dependencies ship every architecture and let their loader pick
  * (`@parcel/watcher-linux-arm64-glibc/watcher.node` is arm64 on purpose inside an x64 build). Those
  * must be judged against the arch their own path declares, not against the slice.
+ *
+ * Why the last token and not the first: these paths are absolute, and the arm64 slice unpacks into
+ * `dist/linux-arm64-unpacked/`, so the output directory announces an arch before the package does.
+ * Reading the first token made every per-arch dependency in that slice look like it claimed arm64 —
+ * `@parcel/watcher-linux-x64-glibc/watcher.node` was reported as "x64, expected arm64 (from its own
+ * path)", which its path plainly does not say. The x64 slice unpacks into `linux-unpacked/`, which
+ * names no arch, so the bug was invisible there and only the arm64 release leg failed.
  */
 function declaredArchFromPath(filePath) {
-  const match = ARCH_TOKEN_PATTERN.exec(filePath)
-  return match ? ARCH_BY_TOKEN[match[1].toLowerCase()] : null
+  const matches = [...String(filePath).matchAll(new RegExp(ARCH_TOKEN_PATTERN, 'gi'))]
+  const last = matches.at(-1)
+  return last ? ARCH_BY_TOKEN[last[1].toLowerCase()] : null
 }
 
 function findArchViolation(filePath, targetArch) {

--- a/config/scripts/verify-linux-glibc-floor.test.mjs
+++ b/config/scripts/verify-linux-glibc-floor.test.mjs
@@ -362,6 +362,30 @@ describe('bundled native binary architecture', () => {
     await rm(dir, { recursive: true, force: true })
   })
 
+  // The arm64 release leg failed here, and only that leg: the slice unpacks into
+  // `dist/linux-arm64-unpacked/`, so the output directory announced an arch before the package did,
+  // and every per-arch dependency inside it looked like it claimed arm64. The x64 slice unpacks
+  // into `linux-unpacked/`, which names none, so the same code read the package name and passed.
+  // @parcel/watcher arriving from upstream is what first put a mismatched pair in the tree.
+  it('reads the package\u2019s arch, not the one the output directory announces', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'orca-elf-arch-'))
+    const pkg = join(
+      dir,
+      'dist',
+      'linux-arm64-unpacked',
+      'resources',
+      'node_modules',
+      '@parcel',
+      'watcher-linux-x64-glibc'
+    )
+    await mkdir(pkg, { recursive: true })
+    const file = join(pkg, 'watcher.node')
+    await writeFile(file, elfHeader(ELF_MACHINE_BY_ARCH.x64))
+    expect(declaredArchFromPath(file)).toBe('x64')
+    expect(findArchViolation(file, 'arm64')).toBeNull()
+    await rm(dir, { recursive: true, force: true })
+  })
+
   // But a path that names an arch must actually hold it — this is the Pi 5 failure.
   it('flags a binary that contradicts the architecture its own path names', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'orca-elf-arch-'))
@@ -372,6 +396,18 @@ describe('bundled native binary architecture', () => {
     expect(findArchViolation(file, 'arm64')).toMatchObject({ actual: 'x64', expectedArch: 'arm64' })
     // Still caught even when the slice being built is x64.
     expect(findArchViolation(file, 'x64')).toMatchObject({ actual: 'x64', expectedArch: 'arm64' })
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('still flags a mismatch the package\u2019s own name promises', async () => {
+    // The output directory must not excuse a violation either: a package that says arm64 and holds
+    // x86-64 is the Pi 5 failure wherever it is unpacked.
+    const dir = await mkdtemp(join(tmpdir(), 'orca-elf-arch-'))
+    const nested = join(dir, 'dist', 'linux-arm64-unpacked', 'bin', 'linux-arm64-148')
+    await mkdir(nested, { recursive: true })
+    const file = join(nested, 'node-pty.node')
+    await writeFile(file, elfHeader(ELF_MACHINE_BY_ARCH.x64))
+    expect(findArchViolation(file, 'arm64')).toMatchObject({ actual: 'x64', expectedArch: 'arm64' })
     await rm(dir, { recursive: true, force: true })
   })
 

--- a/docs/release-notes/1.4.196-rc.1.md
+++ b/docs/release-notes/1.4.196-rc.1.md
@@ -1,0 +1,10 @@
+# 1.4.196-rc.1
+
+Picks up upstream's work through v1.4.196.
+
+- SSH and remote hosts — 30 fixes
+- Worktrees — 24 fixes
+- Terminal — 23 fixes
+- Native chat — 18 fixes
+- New: host-stamped remote foreground identity
+- New: unify local agent entrypoint routing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta",
-  "version": "1.4.196-rc.0",
+  "version": "1.4.196-rc.1",
   "description": "Next-gen IDE for parallel agentic development",
   "homepage": "https://github.com/paidaxingyo666/Manta",
   "author": "Manta",


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​90 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​73 |

<!-- /manta-pr-loc -->

rc.0's arm64 leg failed and the draft never published — the release gate worked
exactly as designed, nothing half-shipped. This is the fix and the re-cut.

## The bug

`verify-linux-glibc-floor.cjs` judges a per-arch vendored package by the
architecture its own path names, so `@parcel/watcher-linux-arm64-glibc` is
allowed inside an x64 build. It read the **first** arch token in an absolute
path — and the arm64 slice unpacks into `dist/linux-arm64-unpacked/`, so the
output directory announces an arch before the package does. Every per-arch
dependency in that slice looked like it claimed arm64:

```
resources/node_modules/@parcel/watcher-linux-x64-glibc/watcher.node
  is x64, expected arm64 (from its own path)
```

Its path plainly does not say arm64. The x64 slice unpacks into
`linux-unpacked/`, which names no arch, so the same code read the package name
and passed — the bug could only ever fail the arm64 leg, and only once a
dependency shipping a non-matching arch was present. `@parcel/watcher` arriving
from upstream in #16953 supplied one; the arm64 leg was green on 2026-08-30.

Reading the last token scopes the question to the innermost segment, which is
the package. The regression test fails on the old code; a second test pins that a
package promising arm64 while holding x86-64 — the Pi 5 failure this gate exists
for — is still caught wherever it is unpacked.

## Two things the first live release exposed

- **The cut computed an rc that already existed.** `highestRcForBase` reads local
  tags, and the tags are created by CI now, so a clone that has only pulled
  branches has none of them. The origin check caught it, but only after the work.
  The fetch is a `v*` refspec rather than `--tags`, because this clone also
  fetches upstream, whose mobile tags share names with the fork's — `--tags`
  aborts the whole fetch on "would clobber existing tag".
- **The notes described the tag range, not the release.** rc.0 published nothing,
  so rc.1's draft read `- 2 changes`. Notes now start from the last *published*
  release, which is what a reader is actually coming from.

## What rc.1 ships

```
# 1.4.196-rc.1

Picks up upstream's work through v1.4.196.

- SSH and remote hosts — 30 fixes
- Worktrees — 24 fixes
- Terminal — 23 fixes
- Native chat — 18 fixes
- New: host-stamped remote foreground identity
- New: unify local agent entrypoint routing
```

No mobile tags: `mobile/app.json` is unchanged, and `mobile-ios-v0.0.47` /
`mobile-android-v0.0.47` are already building from the rc.0 cut.

https://claude.ai/code/session_013K4DZ2kn4GTKEqLsagKYdj