### PR TITLE
fix(relay): retry a push on a fresh session when the cached one is dead

### DIFF
--- a/relay-server/src/push/apns-sender.test.ts
+++ b/relay-server/src/push/apns-sender.test.ts
@@ -1,0 +1,115 @@
+import { createServer, type Http2Server, type ServerHttp2Stream } from 'node:http2'
+import type { AddressInfo } from 'node:net'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { ApnsSender } from './apns-sender.js'
+
+/**
+ * The one file in this directory that had no test, and the one that dropped
+ * every notification for three days.
+ *
+ * These run against a real h2c server rather than a mocked session: what broke
+ * was the lifetime of a cached `ClientHttp2Session`, which a stub does not have.
+ */
+
+// A key APNs will never see; ApnsProviderToken only has to be able to sign with it.
+const PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgevZzL1gdAFr88hb2
+OF/2NxApJCzGCEDdfSp6VQO30hyhRANCAAQRWz+jn65BtOMvdyHKcvjBeBSDZH2r
+1RTwjmYSi9R/zpBnuQ4EiMnCqfMPWiZqB4QdbAd0E7oH50VpuZ1P087G
+-----END PRIVATE KEY-----`
+
+const CREDENTIALS = { privateKey: PRIVATE_KEY, keyId: 'ABCDE12345', teamId: 'FGHIJ67890' }
+const REQUEST = { deviceToken: 'a'.repeat(64), payload: { aps: { alert: 'hi' } } }
+
+describe('ApnsSender', () => {
+  let server: Http2Server
+  let host: string
+  /** What each successive request should do, consumed in order. */
+  let script: ((stream: ServerHttp2Stream) => void)[]
+  let requests: number
+
+  beforeEach(async () => {
+    script = []
+    requests = 0
+    server = createServer()
+    server.on('stream', (stream) => {
+      const step = script[requests] ?? script.at(-1)
+      requests += 1
+      step?.(stream)
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    host = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+  })
+
+  afterEach(async () => {
+    await new Promise((resolve) => server.close(resolve))
+  })
+
+  const ok = (stream: ServerHttp2Stream) => {
+    stream.respond({ ':status': 200 })
+    stream.end()
+  }
+  const reject = (status: number, reason: string) => (stream: ServerHttp2Stream) => {
+    stream.respond({ ':status': status })
+    stream.end(JSON.stringify({ reason }))
+  }
+  /** The peer vanishing mid-request, which is what a dead cached session looks like. */
+  const reset = (stream: ServerHttp2Stream) => {
+    stream.session?.destroy()
+  }
+
+  it('delivers a push', async () => {
+    script = [ok]
+    await expect(
+      new ApnsSender(CREDENTIALS, 'cn.example.app', host).send(REQUEST)
+    ).resolves.toEqual({ ok: true })
+  })
+
+  it('retries on a fresh session when the cached one is dead', async () => {
+    // The bug: APNs closes an idle connection without the relay being told, so
+    // the next send writes into a dead socket and reads ECONNRESET. Before this
+    // retry existed the push was simply lost — the relay logged `push.failed`
+    // with `Error: read ECONNRESET` and moved on.
+    script = [reset, ok]
+    const sender = new ApnsSender(CREDENTIALS, 'cn.example.app', host)
+    await expect(sender.send(REQUEST)).resolves.toEqual({ ok: true })
+    expect(requests).toBe(2)
+    sender.close()
+  })
+
+  it('gives up after one transport retry', async () => {
+    // A relay that cannot reach APNs at all must report it, not spin.
+    script = [reset, reset, ok]
+    const sender = new ApnsSender(CREDENTIALS, 'cn.example.app', host)
+    const result = await sender.send(REQUEST)
+    expect(result.ok).toBe(false)
+    expect(requests).toBe(2)
+    sender.close()
+  })
+
+  it('does not retry a token APNs has rejected', async () => {
+    // Retrying a dead token wastes a round trip and cannot succeed; the caller
+    // is told to discard it instead.
+    script = [reject(400, 'BadDeviceToken')]
+    const sender = new ApnsSender(CREDENTIALS, 'cn.example.app', host)
+    expect(await sender.send(REQUEST)).toMatchObject({
+      ok: false,
+      discardToken: true,
+      reason: 'BadDeviceToken'
+    })
+    expect(requests).toBe(1)
+    sender.close()
+  })
+
+  it('reuses the session across sends while it is alive', async () => {
+    // The caching is the point — reconnecting per push would cost a TLS
+    // handshake each time. Only a dead session should be replaced.
+    script = [ok]
+    const sender = new ApnsSender(CREDENTIALS, 'cn.example.app', host)
+    await sender.send(REQUEST)
+    await sender.send(REQUEST)
+    expect(requests).toBe(2)
+    sender.close()
+  })
+})

--- a/relay-server/src/push/apns-sender.ts
+++ b/relay-server/src/push/apns-sender.ts
@@ -57,7 +57,26 @@ export class ApnsSender {
       this.token.invalidate()
       return this.attempt(request)
     }
+    // status 0 is the transport failing before APNs answered at all, and between
+    // two pushes hours apart that is almost always the cached session: Apple
+    // closes an idle connection without telling the relay, so the next send
+    // writes into a dead socket and reads ECONNRESET. `closed` and `destroyed`
+    // are both still false at that point, so connectSession() hands the corpse
+    // back and the notification is lost. Drop it and try once on a fresh one.
+    //
+    // Every push this relay attempted failed this way for three days. The result
+    // even said `retryable: true` — produced here, read by nobody.
+    if (!first.ok && first.status === 0) {
+      this.discardSession()
+      return this.attempt(request)
+    }
     return first
+  }
+
+  /** Forget the cached session so the next attempt dials a new one. */
+  private discardSession(): void {
+    this.session?.destroy()
+    this.session = null
   }
 
   close(): void {


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​115 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​115 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |

<!-- /manta-pr-loc -->

Notifications stopped. The first guess was that the sync merge clobbered
something; the second was that TestFlight had flipped APNs from sandbox to
production. Both wrong — and the second is wrong in a useful way, because the
relay's own code calls that "the single most common reason a push that works in
Xcode goes nowhere from TestFlight", and it was already configured correctly.

## What the relay was actually doing

```
{"ts":"2026-09-01T06:24:33Z","event":"push.failed","reason":"Error: read ECONNRESET"}
{"ts":"2026-09-01T10:35:49Z","event":"push.failed","reason":"Error: read ECONNRESET"}
{"ts":"2026-09-01T14:03:13Z","event":"push.failed","reason":"Error: read ECONNRESET"}
{"ts":"2026-09-02T02:15:00Z","event":"push.failed","reason":"Error: read ECONNRESET"}
{"ts":"2026-09-02T07:53:11Z","event":"push.failed","reason":"Error: read ECONNRESET"}
{"ts":"2026-09-04T01:12:47Z","event":"push.failed","reason":"Error: read ECONNRESET"}
```

Every push since the relay came up on 2026-09-01, the same way — so this predates
the mobile update it looked like it followed. `MANTA_RELAY_APNS_ENVIRONMENT` is
`production`, the topic matches the bundle id, the key loads and `apns.ready`
logs cleanly. This is the transport dying before APNs answered at all.

## Why

Pushes are hours apart, and APNs closes an idle connection without telling the
sender. `ClientHttp2Session.closed` and `.destroyed` are **both still false**
then, so `connectSession()`'s liveness check handed back a dead session, the send
wrote into a socket that was already gone, and the read came back RST.

The failure was even labelled for it:

```ts
stream.on('error', (error) => resolve(failure(0, String(error), true)))
//                                                          ^^^^ retryable
```

`retryable` is produced in three places and read in none — `rg retryable
relay-server/src` finds only the type and the constructor. Nothing retried
anything, so each notification was logged and dropped.

## The change

`status === 0` is the transport failing before a response, which is the one case
a fresh connection fixes: discard the session, try once. A token APNs has
rejected still gets no retry, because retrying it cannot succeed.

## Tests

`apns-sender.ts` was the only file in `relay-server/src/push/` without a test,
and what it shipped was a *session lifetime* — which a stubbed session does not
have. These run against a real h2c server that destroys the connection on cue.
Two of the five fail without the fix:

```
× retries on a fresh session when the cached one is dead
× gives up after one transport retry
```

relay-server: 25 files, 199 tests passing; typecheck clean.

https://claude.ai/code/session_0157B63ZJpcK8RxxqLz6v54K