### PR TITLE
fix(relay): let the Docker deploy actually set MANTA_RELAY_METRICS_TOKEN

### DIFF
--- a/relay-server/deploy/.env.example
+++ b/relay-server/deploy/.env.example
@@ -65,3 +65,11 @@ MANTA_RELAY_ALLOW_REGISTRATION=
 # How many machines one account may claim. Bounds how much state a single
 # account can make the relay keep.
 MANTA_RELAY_MAX_HOSTS_PER_ACCOUNT=16
+
+# Bearer token guarding /metrics; unset means the endpoint is not served at all.
+# Worth setting: a push that succeeds logs nothing, so these counters are the
+# only way to tell "no notifications were due" from "every one of them failed" —
+# which is how a dead APNs connection went unnoticed for three days. Caddy 404s
+# the path from outside, so it is reachable only on the host.
+#   openssl rand -base64 32
+MANTA_RELAY_METRICS_TOKEN=

--- a/relay-server/deploy/docker-compose.yml
+++ b/relay-server/deploy/docker-compose.yml
@@ -29,6 +29,11 @@ services:
       # allowed to speak for a client. Without this every phone shares one
       # rate-limit bucket — the proxy's.
       MANTA_RELAY_TRUSTED_PROXIES: "private"
+      # Guards /metrics, which is not served at all without it. Worth setting:
+      # a push that succeeds logs nothing, so the counters are the only way to
+      # tell "no notifications were due" from "every one of them failed". Caddy
+      # 404s the path from outside, so this is reachable only on the host.
+      MANTA_RELAY_METRICS_TOKEN: "${MANTA_RELAY_METRICS_TOKEN:-}"
       # Push is opt-in. Set all four in .env to enable it, or none to leave it
       # off — the relay refuses to start on a partial set rather than running
       # quietly without push. The key is a PATH, never its contents: an env


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 |

<!-- /manta-pr-loc -->

Found while diagnosing the push outage in #19.

`MANTA_RELAY_METRICS_TOKEN` is documented in the README's environment table and
read by `config.ts`, but `deploy/docker-compose.yml` never passed it through and
`deploy/.env.example` never mentioned it. On the deployment path the README
recommends, `/metrics` therefore could not be enabled at all — setting the
variable in `.env` did nothing.

That is exactly the observability that was missing. A push that succeeds logs
nothing; a push that fails is a `warn` nobody reads. `manta_relay_push_total`
is the only thing that separates "no notifications were due" from "every one of
them was lost" — and the second is what had been happening for three days.

Caddy already answers 404 on `/metrics` from outside, so the endpoint stays
reachable only on the host.

https://claude.ai/code/session_0157B63ZJpcK8RxxqLz6v54K