### PR TITLE
fix(relay): reinstall the endpoint override the sync dropped — and cut 1.4.196-rc.2

### DIFF
--- a/docs/release-notes/1.4.196-rc.2.md
+++ b/docs/release-notes/1.4.196-rc.2.md
@@ -1,0 +1,7 @@
+# 1.4.196-rc.2
+
+Restores mobile notifications, which stopped working in rc.1.
+
+- The desktop reaches the relay again — the setting pointing it at a self-hosted
+  server had stopped being read, so it silently never connected
+- Pushes survive an idle connection instead of being dropped

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta",
-  "version": "1.4.196-rc.1",
+  "version": "1.4.196-rc.2",
   "description": "Next-gen IDE for parallel agentic development",
   "homepage": "https://github.com/paidaxingyo666/Manta",
   "author": "Manta",

--- a/src/main/manta-profiles/manta-cloud-endpoint-wiring.test.ts
+++ b/src/main/manta-profiles/manta-cloud-endpoint-wiring.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { execFileSync } from 'node:child_process'
+
+/**
+ * The self-hosted relay is configured in Settings, and exactly one line carries
+ * that setting into the auth config:
+ *
+ *   setMantaCloudEndpointOverrideSource(() => state.store?.getSettings().mantaCloudEndpoints ?? null)
+ *
+ * `readEndpointOverrides` defaults to `() => null`, so without that call
+ * `getMantaCloudAuthConfig()` reports "not configured" — and the startup path
+ * then skips `DesktopRelayService` entirely, inside an `if`, with no warning.
+ * The phone keeps dialling the relay, finds no host, and retries forever.
+ *
+ * That is what happened: upstream moved this startup block from `index.ts` into
+ * `startup/main-process-ready-foundation.ts`, the fork's line did not travel
+ * with it, and the desktop stopped reaching the relay the moment the release
+ * carrying that sync installed itself. Nothing failed loudly; the setting simply
+ * stopped being read.
+ */
+
+const projectDir = resolve(import.meta.dirname, '../../..')
+const git = (...args: string[]) =>
+  execFileSync('git', args, { cwd: projectDir, encoding: 'utf8' }).trim()
+
+/** Production callers — the definition and the test-only reset do not count. */
+function productionCallers(): string[] {
+  return git('grep', '-l', 'setMantaCloudEndpointOverrideSource(', '--', 'src/main')
+    .split('\n')
+    .filter(Boolean)
+    .filter((file) => !file.endsWith('.test.ts'))
+    .filter((file) => !file.endsWith('profile-cloud-auth-config.ts'))
+}
+
+describe('Manta cloud endpoint wiring', () => {
+  it('is installed by the startup path, not merely exported', () => {
+    // An injected setter with no caller is a feature that is off and says
+    // nothing. Naming the file keeps the failure message actionable when
+    // upstream moves the startup block again.
+    expect(productionCallers()).toEqual(['src/main/startup/main-process-ready-foundation.ts'])
+  })
+
+  it('reads the setting the Settings pane writes', () => {
+    // The two halves have to agree on the field name; a rename on either side
+    // would leave the reader returning undefined, which is the same silence.
+    const wiring = readFileSync(
+      join(projectDir, 'src/main/startup/main-process-ready-foundation.ts'),
+      'utf8'
+    )
+    expect(wiring).toContain('getSettings().mantaCloudEndpoints')
+    expect(readFileSync(join(projectDir, 'src/shared/manta-cloud-endpoints.ts'), 'utf8')).toContain(
+      'relayDirectorUrl'
+    )
+  })
+})

--- a/src/main/startup/main-process-ready-foundation.ts
+++ b/src/main/startup/main-process-ready-foundation.ts
@@ -10,6 +10,7 @@ import {
   hangDetectionMarkerPath
 } from '../hang-watchdog/hang-detection-marker'
 import { browserCertificateTrustController } from '../browser/browser-manager'
+import { setMantaCloudEndpointOverrideSource } from '../manta-profiles/profile-cloud-auth-config'
 import { ensureActiveMantaProfile } from '../manta-profiles/profile-index-store'
 import { Store, getCanonicalUserDataPath } from '../persistence'
 import { initializeBrowserClientHostId } from '../browser/browser-client-host-id'
@@ -177,6 +178,12 @@ export async function initializeReadyFoundation(): Promise<void> {
     }
   }
   wslHookRelayManager.setManagedHookSettingsResolver(() => state.store?.getSettings() ?? null)
+  // Why: lets packaged builds point sign-in/relay at a self-hosted server without
+  // shell env vars (macOS GUI launches never inherit them). Without this the
+  // override reader stays at its null default, getMantaCloudAuthConfig() reports
+  // "not configured", and main-process-runtime-launch skips the relay service
+  // entirely — the phone then finds no host and retries forever.
+  setMantaCloudEndpointOverrideSource(() => state.store?.getSettings().mantaCloudEndpoints ?? null)
   logStartupMilestone('store-loaded')
   // Why: apply initial fallback WSL distro from store settings for global git/CLI calls.
   setDefaultWslDistroOverride(store.getSettings().terminalWindowsWslDistro ?? null)


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 |

<!-- /manta-pr-loc -->

Notifications stopped. #19 fixed one half of it — the relay was dropping every
push on a dead HTTP/2 session. This is the other half, and the bigger one: since
rc.1 installed itself the desktop has not reached the relay at all.

## What the relay saw

```
/v1/desktop/auth/relay-token   hourly … 07:03  08:01  09:00  ← stops
/v1/host/control               every ~8.5 min … 09:04  09:12  09:19  ← stops
/v1/connect/<host>             every ~15s, still going
```

09:19 is when rc.1 installed and restarted the app. The phone is fine: its
WebSocket upgrade succeeds, the relay finds no host session to pair it with and
closes it, and it retries forever. `manta_relay_sessions` has been 0 since.

## Why

Exactly one line carries the self-hosted endpoints from Settings into the auth
config:

```ts
setMantaCloudEndpointOverrideSource(() => state.store?.getSettings().mantaCloudEndpoints ?? null)
```

`readEndpointOverrides` defaults to `() => null`, so without it
`getMantaCloudAuthConfig()` reports "not configured" — and the startup path then
skips `DesktopRelayService` **inside an `if`, with no warning**:

```ts
const cloudAuth = getMantaCloudAuthConfig()
if (cloudAuth.configured) { … relayService.start() … }
```

Upstream moved that startup block out of `index.ts` into
`startup/main-process-ready-foundation.ts`. The fork's line did not travel with
it: the merge took upstream's side of a file the fork had a single addition in,
and the addition was a *call*, not an import, so nothing dangled and nothing
failed to compile. The settings were still on disk the whole time — nothing was
reading them.

## The test

It pins the wiring by its **caller**, not its export, because an injected setter
with no caller is a feature that is off and says nothing. Both cases fail
without the fix.

This is the class of sync casualty worth naming: a fork-only *call* inside a
file upstream restructures. An orphaned import gets caught by the compiler; an
orphaned injection point does not.

## Version

Cut as `1.4.196-rc.2`, not the `1.4.197-rc.0` the script computed. Upstream has
released 1.4.197 but this fork has not merged it — the version rule takes
upstream's newest *release* rather than what the fork has actually merged, which
is right after a sync and wrong for a fork-only fix. Worth tightening
separately; `refs/sync/base` already knows the true answer.

https://claude.ai/code/session_0157B63ZJpcK8RxxqLz6v54K