### PR TITLE
test: stop the artifact share fixtures expiring on a calendar date

### DIFF
--- a/src/main/artifacts/artifact-cloud-recovery.test.ts
+++ b/src/main/artifacts/artifact-cloud-recovery.test.ts
@@ -342,7 +342,7 @@ function createResponseBody(slug: string): object {
       renderedContentType: 'text/html',
       createdAt: '2026-08-06T00:00:00.000Z',
       updatedAt: '2026-08-06T00:00:00.000Z',
-      expiresAt: '2026-09-06T00:00:00.000Z',
+      expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
       byteSize: 17,
       deletedAt: null
     },

--- a/src/main/artifacts/artifact-cloud-service-races.test.ts
+++ b/src/main/artifacts/artifact-cloud-service-races.test.ts
@@ -33,7 +33,7 @@ function createResponse(slug: string): Response {
         renderedContentType: 'text/html',
         createdAt: '2026-08-06T00:00:00.000Z',
         updatedAt: '2026-08-06T00:00:00.000Z',
-        expiresAt: '2026-09-06T00:00:00.000Z',
+        expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
         byteSize: 12,
         deletedAt: null
       },

--- a/src/main/artifacts/artifact-cloud-service.test.ts
+++ b/src/main/artifacts/artifact-cloud-service.test.ts
@@ -43,7 +43,10 @@ const cloudB: MantaProfileCloudSummary = {
   linkedAt: 2
 }
 
-function createResponse(slug = 'artifact-a', expiresAt = '2026-09-06T00:00:00.000Z'): Response {
+function createResponse(
+  slug = 'artifact-a',
+  expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString()
+): Response {
   return new Response(
     JSON.stringify({
       artifact: {


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /manta-pr-loc -->

`verify` is red on every open PR, and nothing in them caused it.

Three artifact fixtures minted share records with `expiresAt: '2026-09-06'`.
The record store drops anything already expired, so once that date passed every
mapping lookup returned nothing and eleven tests across three files started
failing on code that had not changed. The last green run happened hours before
the date, which is why the sync PR merged clean and the next PR opened red.

The expiry is now thirty days out from whenever the test runs, so the fixture
is a live record instead of a countdown. This is upstream's own fix for the
same failure (#18955), applied here rather than waiting for the next sync. The
one call that passes an explicit date keeps it — that path is deliberate.

Verified: `src/main/artifacts/` goes 69/69 with this, 58/69 without.