### PR TITLE
feat(relay): let a self-hosted relay serve the artifacts it pairs

### DIFF
--- a/relay-server/README.md
+++ b/relay-server/README.md
@@ -126,6 +126,8 @@ endpoints.
 | `MANTA_RELAY_MAX_SESSIONS` | `64` | Desktops on this cell. |
 | `MANTA_RELAY_MAX_CONNS_PER_HOST` | `8` | Concurrent phone connections per desktop. Cannot exceed 8 — see below. |
 | `MANTA_RELAY_SHUTDOWN_GRACE_MS` | `5000` | How long peers get to migrate on SIGTERM. |
+| `MANTA_RELAY_ARTIFACTS` | off | Serve published artifacts. See "Artifact hosting". |
+| `MANTA_RELAY_ARTIFACTS_PUBLIC_URL` | — | **Required when artifacts are on.** Origin links point at; must not be the relay's. |
 
 Rate limits are `MANTA_RELAY_{PHONE,HTTP,AUTH,CONTROL}_{BURST,RATE}`; the
 defaults are sized for a household, not a public service. Everything else is in
@@ -305,6 +307,86 @@ host proof, and a change is an undiagnosable 4401.
 `cell-state.json` in `MANTA_RELAY_DATA_DIR`, written 0600 with the same
 fsync-and-rename discipline. Passwords are stored as scrypt hashes.
 
+## Artifact hosting (optional, off)
+
+The desktop can publish a file as a page and hand out the link. Upstream runs
+the host that serves those pages; this relay can be that host instead, and does
+nothing of the sort unless you switch it on.
+
+**Turning it on changes what this deployment is.** Everywhere else, the relay is
+a byte pipe: it stores credentials, forwards frames it cannot read, and serves
+nothing to the public. Artifacts make it a content host that keeps pages —
+written by whoever publishes them — and serves them to anyone with the link.
+Your disk, your bandwidth, and whatever rules you operate under. That is why it
+is off by default and why enabling it takes two variables rather than one.
+
+```bash
+MANTA_RELAY_ARTIFACTS=1
+MANTA_RELAY_ARTIFACTS_PUBLIC_URL=https://share.example.com
+```
+
+Then point a second DNS record at the host, set `ARTIFACTS_DOMAIN`, and
+uncomment the artifact block in `deploy/Caddyfile`.
+
+### The artifact origin must not be the relay origin
+
+The relay refuses to start if they match, and this is the one setting here with
+no "but in my case" — a published artifact runs with the privileges of whatever
+origin serves it. On the relay's origin, a page someone shared could call
+`/v1/desktop/auth/*` and the cell endpoints as the signed-in desktop, using the
+viewer's browser. **The separate origin is the isolation.** Nothing else in this
+section substitutes for it: not the CSP, not the sandbox headers, not the
+markdown escaping.
+
+The write API stays on the relay's name. Only `GET /a/{slug}` is served on the
+artifact origin, so an access token never has a reason to be sent to the origin
+that serves the pages.
+
+### What it does with what you publish
+
+| Source | Stored as | Why |
+| --- | --- | --- |
+| `text/markdown` | HTML this relay rendered | Rendered by `src/artifacts/markdown.ts`, which escapes every byte first and then builds a small, fixed set of tags. Raw HTML in the source shows as text. There is no sanitizer to bypass because nothing is passed through. |
+| `text/html` | exactly what was sent | Rewriting someone's document is not this server's job, and a filter is not what contains it — the origin is. |
+
+So an HTML artifact **is** arbitrary script on the artifact origin, by design.
+That is the feature working, and it is the reason for every paragraph above.
+
+Published pages carry `X-Frame-Options: DENY`, `nosniff`, `no-referrer`,
+`no-store`, and a CSP of `frame-ancestors 'none'; base-uri 'none'; form-action
+'none'` — the escapes that survive origin isolation, closed.
+
+### Limits, and why they are not optional
+
+The relay cannot police what people publish. It can only bound how much, which
+is what stands between one enthusiastic user and a full disk:
+
+| Variable | Default | Bounds |
+| --- | --- | --- |
+| `MANTA_RELAY_ARTIFACTS_MAX_BYTES` | 10 MiB | One artifact. Matches the desktop's own ceiling. |
+| `MANTA_RELAY_ARTIFACTS_MAX_PER_ACCOUNT` | 100 | Artifacts one account may hold. |
+| `MANTA_RELAY_ARTIFACTS_MAX_TOTAL_BYTES` | 256 MiB | Bytes one account may hold. |
+| `MANTA_RELAY_ARTIFACTS_TTL_MS` | 30 days | How long a link lives; you pay for the storage until it expires. |
+
+Under `MANTA_RELAY_ACCOUNTS=shared` every desktop holding the enrolment secret
+is one account and shares one allowance. `per-user` is what gives each person
+their own, and their own artifacts.
+
+**State.** `artifacts/index.json` plus one file per page under
+`artifacts/bodies/` in `MANTA_RELAY_DATA_DIR`. Without a data directory the
+pages are held in memory and every link breaks on restart; startup says so.
+Expired records and their files are swept on the next request.
+
+**Authentication** is the session the auth server already minted — the same
+bearer, checked against the same store. Writes to an existing artifact also
+carry an edit token, derived from the slug rather than stored, so a create whose
+response was lost can be retried with the same idempotency key and get the same
+token back.
+
+**Point the desktop at it** under Settings → Advanced → Manta Cloud →
+Configure endpoints → **Artifact host**. It is deliberately not derived from the
+relay address, for the reason above.
+
 ## Observability
 
 - `GET /health` — unauthenticated, `{"ok":true}`, `503` while draining so a load
@@ -312,7 +394,9 @@ fsync-and-rename discipline. Passwords are stored as scrypt hashes.
 - `GET /metrics` — Prometheus text, behind `MANTA_RELAY_METRICS_TOKEN`. Counters
   for phone connects and rejections (by reason), host rejections (by reason),
   rate-limit refusals (by surface), credential installs, bytes forwarded;
-  gauges for live sessions, pairs, and stored hosts.
+  gauges for live sessions, pairs, and stored hosts. With artifacts on,
+  `manta_relay_artifacts_total` by operation and gauges for the stored count and
+  the bytes they occupy — the byte total is the one that fills a disk.
 - Logs are JSON lines. Credential-shaped fields are redacted by field name, so
   a debug-level log of a control message does not print a resume token.
 

--- a/relay-server/deploy/.env.example
+++ b/relay-server/deploy/.env.example
@@ -73,3 +73,45 @@ MANTA_RELAY_MAX_HOSTS_PER_ACCOUNT=16
 # the path from outside, so it is reachable only on the host.
 #   openssl rand -base64 32
 MANTA_RELAY_METRICS_TOKEN=
+
+# ---------------------------------------------------------------------------
+# Artifact hosting (optional, off)
+# ---------------------------------------------------------------------------
+# Turning this on changes what this deployment is. The relay is a byte pipe
+# that stores credentials and forwards frames it cannot read; artifacts make it
+# a content host that serves pages — written by whoever publishes them — to
+# anyone holding the link. That is a decision about your disk, your bandwidth,
+# and the rules you operate under, so it is never a default.
+#
+# What it gives you: the desktop's "share" produces a working public link
+# against your own server instead of a host you do not run.
+#
+#   1 / true / yes / on   enable
+#   anything else         off
+MANTA_RELAY_ARTIFACTS=
+
+# The origin published links point at. Required when the feature is on, and it
+# MUST NOT be the relay's origin — the relay refuses to start if it is.
+#
+# Why a separate name and not a path: a published artifact runs with the
+# privileges of whatever origin serves it. On the relay's origin, a page someone
+# shared could call /v1/desktop/auth/* and the cell endpoints as the signed-in
+# desktop. The separate origin IS the isolation; nothing else here replaces it.
+#
+# Point a second DNS record at this host, set ARTIFACTS_DOMAIN, and uncomment
+# the artifact block in the Caddyfile.
+MANTA_RELAY_ARTIFACTS_PUBLIC_URL=
+ARTIFACTS_DOMAIN=
+
+# Per-artifact ceiling. Matches the desktop's own limit; raising it past that
+# only wastes the space, since the app refuses to send more.
+MANTA_RELAY_ARTIFACTS_MAX_BYTES=10485760
+
+# How long a published link lives. It has to outlast the conversation it was
+# shared in, and you pay for the storage until it expires.
+MANTA_RELAY_ARTIFACTS_TTL_MS=2592000000
+
+# Per-account allowances. These are what stand between one enthusiastic user
+# and a full disk — the relay cannot police what people publish, only how much.
+MANTA_RELAY_ARTIFACTS_MAX_PER_ACCOUNT=100
+MANTA_RELAY_ARTIFACTS_MAX_TOTAL_BYTES=268435456

--- a/relay-server/deploy/Caddyfile
+++ b/relay-server/deploy/Caddyfile
@@ -39,6 +39,25 @@
 	file_server
 }
 
+# Artifact hosting, if it is switched on. Its own name, and that is the point:
+# a published artifact is a page its author wrote and it runs on the origin that
+# serves it, so sharing the relay's would let one call the relay as the
+# signed-in desktop. The relay refuses to start if the two origins match.
+#
+# Commented out because the feature is off by default. To enable it, set
+# ARTIFACTS_DOMAIN, uncomment this block, and see MANTA_RELAY_ARTIFACTS in
+# .env.example.
+#
+#{$ARTIFACTS_DOMAIN} {
+#	import hardened
+#
+#	# Only the public page. The write API stays on the relay's own name, so a
+#	# token never has a reason to be sent to the origin that serves the pages.
+#	@artifact path /a/*
+#	reverse_proxy @artifact relay:8787
+#	respond 404
+#}
+
 {$RELAY_DOMAIN} {
 	import hardened
 

--- a/relay-server/deploy/docker-compose.yml
+++ b/relay-server/deploy/docker-compose.yml
@@ -105,6 +105,9 @@ services:
     environment:
       RELAY_DOMAIN: "${RELAY_DOMAIN:?set RELAY_DOMAIN}"
       SITE_DOMAIN: "${SITE_DOMAIN:?set SITE_DOMAIN}"
+      # Only used by the artifact block in the Caddyfile, which is commented out
+      # until an operator turns artifact hosting on. Empty is fine while it is.
+      ARTIFACTS_DOMAIN: "${ARTIFACTS_DOMAIN:-}"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       # The filing requires the domain to serve a page; this mounts it. The page

--- a/relay-server/src/artifacts.test.ts
+++ b/relay-server/src/artifacts.test.ts
@@ -1,0 +1,392 @@
+/**
+ * The artifact surface over real HTTP against a real relay.
+ *
+ * Everything here goes through fetch rather than calling the handler, because
+ * the parts most likely to be wrong are the ones a direct call skips: the
+ * status codes the desktop branches on, the headers the public page carries,
+ * and the fact that the bearer is the auth server's session and not a
+ * credential this module invented.
+ */
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { assertArtifactOrigins } from './config.js'
+import { PER_USER, startTestRelay, type TestRelay } from './testing/harness.js'
+
+let current: TestRelay | null = null
+const dirs: string[] = []
+
+afterEach(async () => {
+  await current?.stop()
+  current = null
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+const SHARE_ORIGIN = 'https://share.example.test'
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'manta-relay-artifacts-'))
+  dirs.push(dir)
+  return dir
+}
+
+async function startWithArtifacts(extra: Record<string, unknown> = {}): Promise<TestRelay> {
+  const dataDir = tempDir()
+  return startTestRelay(() => ({
+    ...PER_USER,
+    dataDir,
+    artifacts: {
+      enabled: true,
+      publicUrl: SHARE_ORIGIN,
+      maxBytes: 10 * 1024 * 1024,
+      ttlMs: 30 * 24 * 60 * 60_000,
+      maxPerAccount: 100,
+      maxTotalBytesPerAccount: 256 * 1024 * 1024,
+      ...extra
+    }
+  })) as Promise<TestRelay>
+}
+
+async function signIn(origin: string, email = 'ada@example.com'): Promise<string> {
+  const response = await fetch(`${origin}/v1/desktop/auth/register`, {
+    method: 'POST',
+    headers: { connection: 'close', 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password: 'correct-horse' })
+  })
+  if (!response.ok) {
+    throw new Error(`register failed: ${response.status}`)
+  }
+  return ((await response.json()) as { accessToken: string }).accessToken
+}
+
+function api(
+  origin: string,
+  path: string,
+  token: string,
+  init: { method?: string; body?: unknown; editToken?: string; idempotencyKey?: string } = {}
+): Promise<Response> {
+  return fetch(`${origin}/v1/artifacts${path}`, {
+    method: init.method ?? 'GET',
+    headers: {
+      connection: 'close',
+      authorization: `Bearer ${token}`,
+      ...(init.editToken ? { 'x-manta-edit-token': init.editToken } : {}),
+      ...(init.idempotencyKey ? { 'idempotency-key': init.idempotencyKey } : {}),
+      ...(init.body ? { 'content-type': 'application/json' } : {})
+    },
+    ...(init.body ? { body: JSON.stringify(init.body) } : {})
+  })
+}
+
+const HTML_BODY = {
+  content: '<h1>Report</h1>',
+  contentType: 'text/html',
+  fileName: 'report.html',
+  title: 'Report'
+}
+
+type Created = {
+  artifact: { slug: string; expiresAt: string; byteSize: number; sourceContentType: string }
+  shareUrl: string
+  editToken: string
+}
+
+describe('artifact hosting is off unless asked for', () => {
+  it('answers 404 on the API and the public path when disabled', async () => {
+    current = await startTestRelay(() => PER_USER)
+    const token = await signIn(current.origin)
+    expect((await api(current.origin, '', token)).status).toBe(404)
+    expect((await fetch(`${current.origin}/a/anything`)).status).toBe(404)
+    expect(current.relay.artifacts).toBeNull()
+  })
+})
+
+describe('artifact origin separation', () => {
+  it('refuses to start when the artifact origin is the relay origin', () => {
+    // A published artifact runs on the origin that serves it. Sharing the
+    // relay's would let one call the relay's endpoints as the signed-in
+    // desktop, so this is fatal rather than discouraged.
+    expect(() =>
+      assertArtifactOrigins({
+        publicUrl: 'https://relay.example.test',
+        artifacts: { enabled: true, publicUrl: 'https://relay.example.test' }
+      })
+    ).toThrow(/must not be the relay origin/)
+  })
+
+  it('requires an origin to publish links against', () => {
+    expect(() =>
+      assertArtifactOrigins({
+        publicUrl: 'https://relay.example.test',
+        artifacts: { enabled: true, publicUrl: '' }
+      })
+    ).toThrow(/is required/)
+  })
+
+  it('refuses an origin carrying a path', () => {
+    expect(() =>
+      assertArtifactOrigins({
+        publicUrl: 'https://relay.example.test',
+        artifacts: { enabled: true, publicUrl: 'https://share.example.test/files' }
+      })
+    ).toThrow(/bare origin/)
+  })
+
+  it('says nothing about any of it while the feature is off', () => {
+    expect(() =>
+      assertArtifactOrigins({
+        publicUrl: 'https://relay.example.test',
+        artifacts: { enabled: false, publicUrl: '' }
+      })
+    ).not.toThrow()
+  })
+})
+
+describe('publishing', () => {
+  it('creates, lists, updates, and deletes through the desktop contract', async () => {
+    current = await startWithArtifacts()
+    const token = await signIn(current.origin)
+
+    const created = await api(current.origin, '', token, { method: 'POST', body: HTML_BODY })
+    expect(created.status).toBe(201)
+    const body = (await created.json()) as Created
+    expect(body.shareUrl).toBe(`${SHARE_ORIGIN}/a/${body.artifact.slug}`)
+    expect(body.editToken).toBeTruthy()
+    expect(body.artifact.sourceContentType).toBe('text/html')
+    expect(Date.parse(body.artifact.expiresAt)).toBeGreaterThan(Date.now())
+
+    const listed = await api(current.origin, '', token)
+    expect(listed.status).toBe(200)
+    const page = (await listed.json()) as { artifacts: { artifact: { slug: string } }[] }
+    expect(page.artifacts.map((entry) => entry.artifact.slug)).toEqual([body.artifact.slug])
+
+    const updated = await api(current.origin, `/${body.artifact.slug}`, token, {
+      method: 'PUT',
+      editToken: body.editToken,
+      body: { ...HTML_BODY, content: '<h1>Revised</h1>' }
+    })
+    expect(updated.status).toBe(200)
+    expect(await (await fetch(`${current.origin}/a/${body.artifact.slug}`)).text()).toContain(
+      'Revised'
+    )
+
+    const deleted = await api(current.origin, `/${body.artifact.slug}`, token, {
+      method: 'DELETE',
+      editToken: body.editToken
+    })
+    expect(deleted.status).toBe(204)
+    expect((await fetch(`${current.origin}/a/${body.artifact.slug}`)).status).toBe(404)
+  })
+
+  it('replays a create whose response was lost, with the same edit token', async () => {
+    // The desktop retries with the same key and needs the same answer back,
+    // edit token included — it uses that token to finish the publish. Anything
+    // else and a dropped reply becomes two artifacts or a stuck publish.
+    current = await startWithArtifacts()
+    const token = await signIn(current.origin)
+    const first = (await (
+      await api(current.origin, '', token, {
+        method: 'POST',
+        body: HTML_BODY,
+        idempotencyKey: 'key-1'
+      })
+    ).json()) as Created
+
+    const replayed = await api(current.origin, '', token, {
+      method: 'POST',
+      body: { ...HTML_BODY, content: '<h1>Different</h1>' },
+      idempotencyKey: 'key-1'
+    })
+    expect(replayed.status).toBe(200)
+    const second = (await replayed.json()) as Created
+    expect(second.artifact.slug).toBe(first.artifact.slug)
+    expect(second.editToken).toBe(first.editToken)
+
+    const page = (await (await api(current.origin, '', token)).json()) as { artifacts: unknown[] }
+    expect(page.artifacts).toHaveLength(1)
+  })
+
+  it('renders markdown and escapes what it renders', async () => {
+    current = await startWithArtifacts()
+    const token = await signIn(current.origin)
+    const created = (await (
+      await api(current.origin, '', token, {
+        method: 'POST',
+        body: {
+          content: '# Title\n\n<script>alert(1)</script>',
+          contentType: 'text/markdown',
+          fileName: 'note.md'
+        }
+      })
+    ).json()) as Created
+
+    const page = await fetch(`${current.origin}/a/${created.artifact.slug}`)
+    const html = await page.text()
+    expect(html).toContain('<h1>Title</h1>')
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;script&gt;')
+  })
+})
+
+describe('authorization', () => {
+  it('refuses an unauthenticated call', async () => {
+    current = await startWithArtifacts()
+    expect((await fetch(`${current.origin}/v1/artifacts`)).status).toBe(401)
+  })
+
+  it('hides an account from another one, and refuses its writes', async () => {
+    current = await startWithArtifacts()
+    const ada = await signIn(current.origin, 'ada@example.com')
+    const grace = await signIn(current.origin, 'grace@example.com')
+    const mine = (await (
+      await api(current.origin, '', ada, { method: 'POST', body: HTML_BODY })
+    ).json()) as Created
+
+    const theirList = (await (await api(current.origin, '', grace)).json()) as {
+      artifacts: unknown[]
+    }
+    expect(theirList.artifacts).toHaveLength(0)
+
+    // 404 rather than 403: another account's slug is not theirs to learn about.
+    const theirDelete = await api(current.origin, `/${mine.artifact.slug}`, grace, {
+      method: 'DELETE',
+      editToken: mine.editToken
+    })
+    expect(theirDelete.status).toBe(404)
+  })
+
+  it('refuses an update carrying the wrong edit token', async () => {
+    current = await startWithArtifacts()
+    const token = await signIn(current.origin)
+    const created = (await (
+      await api(current.origin, '', token, { method: 'POST', body: HTML_BODY })
+    ).json()) as Created
+    const response = await api(current.origin, `/${created.artifact.slug}`, token, {
+      method: 'PUT',
+      editToken: 'not-the-token',
+      body: HTML_BODY
+    })
+    expect(response.status).toBe(403)
+  })
+
+  it('answers a missing artifact with the pair the desktop treats as gone', async () => {
+    // artifact-cloud-service swallows exactly 404 + artifact_not_found, which
+    // is what makes an interrupted unshare converge instead of retrying.
+    current = await startWithArtifacts()
+    const token = await signIn(current.origin)
+    const response = await api(current.origin, '/does-not-exist', token, { method: 'DELETE' })
+    expect(response.status).toBe(404)
+    expect((await response.json()) as { code: string }).toMatchObject({
+      code: 'artifact_not_found'
+    })
+  })
+})
+
+describe('limits', () => {
+  it('refuses a body over the per-artifact ceiling', async () => {
+    current = await startWithArtifacts({ maxBytes: 1024 })
+    const token = await signIn(current.origin)
+    const response = await api(current.origin, '', token, {
+      method: 'POST',
+      body: { ...HTML_BODY, content: 'x'.repeat(2048) }
+    })
+    expect(response.status).toBe(413)
+  })
+
+  it('refuses one more artifact than the account may hold', async () => {
+    current = await startWithArtifacts({ maxPerAccount: 1 })
+    const token = await signIn(current.origin)
+    expect(
+      (await api(current.origin, '', token, { method: 'POST', body: HTML_BODY })).status
+    ).toBe(201)
+    const second = await api(current.origin, '', token, { method: 'POST', body: HTML_BODY })
+    expect(second.status).toBe(413)
+    expect((await second.json()) as { code: string }).toMatchObject({ code: 'too_many' })
+  })
+
+  it('lets an update land when only its own older copy filled the account', async () => {
+    // The replaced record has to be excluded from the total, or editing an
+    // artifact near the cap is refused for space it is about to release.
+    current = await startWithArtifacts({ maxTotalBytesPerAccount: 200 })
+    const token = await signIn(current.origin)
+    const created = (await (
+      await api(current.origin, '', token, {
+        method: 'POST',
+        body: { ...HTML_BODY, content: 'x'.repeat(150) }
+      })
+    ).json()) as Created
+    const updated = await api(current.origin, `/${created.artifact.slug}`, token, {
+      method: 'PUT',
+      editToken: created.editToken,
+      body: { ...HTML_BODY, content: 'y'.repeat(150) }
+    })
+    expect(updated.status).toBe(200)
+  })
+})
+
+describe('the published page', () => {
+  it('carries the headers that contain a page written by someone else', async () => {
+    current = await startWithArtifacts()
+    const token = await signIn(current.origin)
+    const created = (await (
+      await api(current.origin, '', token, { method: 'POST', body: HTML_BODY })
+    ).json()) as Created
+    const page = await fetch(`${current.origin}/a/${created.artifact.slug}`)
+    expect(page.headers.get('x-frame-options')).toBe('DENY')
+    expect(page.headers.get('x-content-type-options')).toBe('nosniff')
+    expect(page.headers.get('referrer-policy')).toBe('no-referrer')
+    expect(page.headers.get('cache-control')).toBe('no-store')
+    const csp = page.headers.get('content-security-policy') ?? ''
+    expect(csp).toContain("frame-ancestors 'none'")
+    expect(csp).toContain("base-uri 'none'")
+    expect(csp).toContain("form-action 'none'")
+  })
+
+  it('serves an HTML artifact verbatim', async () => {
+    // Rewriting someone's document is not this server's job; the separate
+    // origin is what contains it.
+    current = await startWithArtifacts()
+    const token = await signIn(current.origin)
+    const created = (await (
+      await api(current.origin, '', token, {
+        method: 'POST',
+        body: { ...HTML_BODY, content: '<h1>Kept</h1><script>window.x=1</script>' }
+      })
+    ).json()) as Created
+    const html = await (await fetch(`${current.origin}/a/${created.artifact.slug}`)).text()
+    expect(html).toBe('<h1>Kept</h1><script>window.x=1</script>')
+  })
+})
+
+describe('durability', () => {
+  it('keeps published links working across a restart', async () => {
+    current = await startWithArtifacts()
+    const token = await signIn(current.origin)
+    const created = (await (
+      await api(current.origin, '', token, { method: 'POST', body: HTML_BODY })
+    ).json()) as Created
+    current.relay.artifacts?.flush()
+
+    const { restartTestRelay } = await import('./testing/harness.js')
+    current = await restartTestRelay(current)
+    const page = await fetch(`${current.origin}/a/${created.artifact.slug}`)
+    expect(page.status).toBe(200)
+    expect(await page.text()).toContain('Report')
+  })
+
+  it('stops serving an artifact once it expires and reclaims it', async () => {
+    current = await startWithArtifacts({ ttlMs: 1 })
+    const token = await signIn(current.origin)
+    const created = (await (
+      await api(current.origin, '', token, { method: 'POST', body: HTML_BODY })
+    ).json()) as Created
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect((await fetch(`${current.origin}/a/${created.artifact.slug}`)).status).toBe(404)
+    const page = (await (await api(current.origin, '', token)).json()) as { artifacts: unknown[] }
+    expect(page.artifacts).toHaveLength(0)
+    expect(current.relay.artifacts?.size).toBe(0)
+  })
+})

--- a/relay-server/src/artifacts/markdown.test.ts
+++ b/relay-server/src/artifacts/markdown.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { renderMarkdown } from './markdown.js'
+
+/**
+ * The invariant these cover is not "renders markdown well" — it is that the
+ * output contains no tag this renderer did not construct. Everything a
+ * publisher writes is escaped before any rule runs, so the interesting cases
+ * are the ones where a parser that filtered instead would leak.
+ */
+describe('renderMarkdown escaping', () => {
+  it('shows raw HTML as text rather than passing it through', () => {
+    const html = renderMarkdown('<script>alert(1)</script>')
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;script&gt;')
+  })
+
+  it('keeps an img onerror payload inert', () => {
+    const html = renderMarkdown('<img src=x onerror=alert(1)>')
+    expect(html).not.toContain('<img')
+    expect(html).toContain('&lt;img')
+  })
+
+  it('does not let a code span smuggle a tag out', () => {
+    const html = renderMarkdown('`<b>bold</b>`')
+    expect(html).toContain('<code>&lt;b&gt;bold&lt;/b&gt;</code>')
+    expect(html).not.toContain('<b>')
+  })
+
+  it('refuses a javascript: link and leaves the source visible', () => {
+    const html = renderMarkdown('[click](javascript:alert(1))')
+    expect(html).not.toContain('<a href')
+    expect(html).toContain('javascript:alert(1)')
+  })
+
+  it('refuses a data: link', () => {
+    const html = renderMarkdown('[x](data:text/html;base64,PHNjcmlwdD4=)')
+    expect(html).not.toContain('<a href')
+  })
+
+  it('links http, https, and mailto, always with rel', () => {
+    for (const href of ['https://a.example', 'http://a.example', 'mailto:a@example.com']) {
+      const html = renderMarkdown(`[go](${href})`)
+      expect(html).toContain(`href="${href}"`)
+      expect(html).toContain('rel="noopener noreferrer nofollow"')
+    }
+  })
+
+  it('escapes a quote inside a link label and href', () => {
+    // A raw quote in the href would close the attribute and let the rest of the
+    // URL become attributes of the anchor.
+    const html = renderMarkdown('[a"b](https://a.example/?q="x")')
+    expect(html).toContain('href="https://a.example/?q=&quot;x&quot;"')
+    expect(html).toContain('>a&quot;b</a>')
+  })
+})
+
+describe('renderMarkdown structure', () => {
+  it('renders headings, emphasis, rules, and both list kinds', () => {
+    const html = renderMarkdown(
+      ['# Title', '', 'Some **bold** and _thin_ text.', '', '---', '', '- one', '- two'].join('\n')
+    )
+    expect(html).toContain('<h1>Title</h1>')
+    expect(html).toContain('<strong>bold</strong>')
+    expect(html).toContain('<em>thin</em>')
+    expect(html).toContain('<hr>')
+    expect(html).toContain('<ul>')
+    expect(html).toContain('<li>one</li>')
+
+    const ordered = renderMarkdown(['1. first', '2. second'].join('\n'))
+    expect(ordered).toContain('<ol>')
+    expect(ordered).toContain('<li>second</li>')
+  })
+
+  it('closes a list before the block that follows it', () => {
+    const html = renderMarkdown(['- one', '', 'after'].join('\n'))
+    expect(html.indexOf('</ul>')).toBeLessThan(html.indexOf('<p>after</p>'))
+  })
+
+  it('switches list kind without nesting one inside the other', () => {
+    const html = renderMarkdown(['- bullet', '1. numbered'].join('\n'))
+    expect(html.indexOf('</ul>')).toBeLessThan(html.indexOf('<ol>'))
+  })
+
+  it('keeps a fence open until its own marker returns', () => {
+    const html = renderMarkdown(['~~~', '```', 'still code', '~~~', 'after'].join('\n'))
+    expect(html).toContain('still code')
+    expect(html).toContain('<p>after</p>')
+    expect(html.match(/<pre>/g)).toHaveLength(1)
+  })
+
+  it('renders an unterminated fence rather than dropping the rest of the file', () => {
+    const html = renderMarkdown(['```', 'body line'].join('\n'))
+    expect(html).toContain('body line')
+  })
+
+  it('renders a block quote', () => {
+    expect(renderMarkdown('> quoted')).toContain('<blockquote><p>quoted</p></blockquote>')
+  })
+
+  it('leaves numbers in prose alone', () => {
+    // The code-span placeholder used to be a bare digit between spaces, which
+    // ate text like this and replaced it with nothing.
+    expect(renderMarkdown('ready in 5 minutes')).toContain('<p>ready in 5 minutes</p>')
+  })
+
+  it('strips a NUL so the source cannot forge a placeholder', () => {
+    const forged = `${String.fromCharCode(0)}0${String.fromCharCode(0)} and \`code\``
+    const html = renderMarkdown(forged)
+    expect(html).toContain('<code>code</code>')
+    expect(html).not.toContain(String.fromCharCode(0))
+  })
+})

--- a/relay-server/src/artifacts/markdown.ts
+++ b/relay-server/src/artifacts/markdown.ts
@@ -1,0 +1,196 @@
+/**
+ * Markdown to HTML, with no dependencies and no HTML passthrough.
+ *
+ * Why hand-written rather than a parser plus a sanitizer: this process holds
+ * account credentials and session tokens, and its whole dependency surface is
+ * two packages. A CommonMark parser and an HTML sanitizer would be the largest
+ * thing in it, and the sanitizer would be load-bearing — one bypass and a
+ * shared note becomes script on the artifact origin.
+ *
+ * The order here removes that class of bug instead of filtering it: every byte
+ * is escaped first, so the only tags in the output are ones this file wrote.
+ * Raw HTML in the source is shown as text, which is a documented limitation
+ * rather than a hole. Authors who need real HTML publish an HTML artifact,
+ * which is served verbatim and is why the artifact origin must be its own.
+ *
+ * The supported subset is deliberately small: headings, paragraphs, fenced and
+ * inline code, ordered and unordered lists, block quotes, horizontal rules,
+ * emphasis, and links to http, https, and mailto.
+ */
+
+const SAFE_LINK = /^(https?:\/\/|mailto:)/i
+
+/**
+ * Marks where a code span was lifted out.
+ *
+ * NUL, and stripped from the source before anything runs, because a printable
+ * placeholder cannot work: whatever shape it took would eventually appear in
+ * someone's prose and be substituted back out of it.
+ */
+const SENTINEL = String.fromCharCode(0)
+const SENTINEL_PATTERN = new RegExp(`${SENTINEL}(\\d+)${SENTINEL}`, 'g')
+
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/**
+ * Inline spans, over already-escaped text.
+ *
+ * Code spans are taken first and held aside, so a backtick span containing `**`
+ * or a bracket is not then re-read as emphasis or a link.
+ */
+function inline(escaped: string): string {
+  const codes: string[] = []
+  let text = escaped.replace(/`([^`]+)`/g, (_match, code: string) => {
+    codes.push(`<code>${code}</code>`)
+    return `${SENTINEL}${codes.length - 1}${SENTINEL}`
+  })
+
+  text = text.replace(/\[([^\]\n]*)\]\(([^)\s]+)\)/g, (match, label: string, href: string) => {
+    // The href arrives escaped, so the entities have to come back out for the
+    // scheme check and stay escaped in the attribute, where that form is right.
+    const raw = href
+      .replace(/&amp;/g, '&')
+      .replace(/&#39;/g, "'")
+      .replace(/&quot;/g, '"')
+    if (!SAFE_LINK.test(raw)) {
+      return match
+    }
+    // rel on every link: these pages are written by whoever published them, and
+    // an opener reference would hand one a handle on the page that linked it.
+    return `<a href="${href}" rel="noopener noreferrer nofollow" target="_blank">${label}</a>`
+  })
+
+  text = text
+    .replace(/\*\*([^*\n]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/(^|[^*\w])\*([^*\n]+)\*(?![*\w])/g, '$1<em>$2</em>')
+    .replace(/(^|[^_\w])_([^_\n]+)_(?![_\w])/g, '$1<em>$2</em>')
+
+  return text.replace(SENTINEL_PATTERN, (_match, index: string) => codes[Number(index)] ?? '')
+}
+
+type ListState = { tag: 'ul' | 'ol'; open: boolean }
+
+function closeList(out: string[], list: ListState): void {
+  if (list.open) {
+    out.push(`</${list.tag}>`)
+    list.open = false
+  }
+}
+
+function openList(out: string[], list: ListState, tag: 'ul' | 'ol'): void {
+  if (list.open && list.tag !== tag) {
+    closeList(out, list)
+  }
+  if (!list.open) {
+    out.push(`<${tag}>`)
+    list.tag = tag
+    list.open = true
+  }
+}
+
+/** Renders the supported subset. Never emits a tag it did not construct. */
+export function renderMarkdown(source: string): string {
+  const normalized = source.split(SENTINEL).join('').replace(/\r\n?/g, '\n')
+  const lines = escapeHtml(normalized).split('\n')
+  const out: string[] = []
+  const list: ListState = { tag: 'ul', open: false }
+  let paragraph: string[] = []
+  let quote: string[] = []
+  let fence: { marker: string; body: string[] } | null = null
+
+  const flushParagraph = (): void => {
+    if (paragraph.length > 0) {
+      out.push(`<p>${inline(paragraph.join(' '))}</p>`)
+      paragraph = []
+    }
+  }
+  const flushQuote = (): void => {
+    if (quote.length > 0) {
+      out.push(`<blockquote><p>${inline(quote.join(' '))}</p></blockquote>`)
+      quote = []
+    }
+  }
+  const flushBlocks = (): void => {
+    flushParagraph()
+    flushQuote()
+    closeList(out, list)
+  }
+
+  for (const line of lines) {
+    if (fence) {
+      // Only the same marker closes the fence, so ``` inside a ~~~ block stays
+      // content rather than ending it early.
+      if (line.trimEnd() === fence.marker) {
+        out.push(`<pre><code>${fence.body.join('\n')}</code></pre>`)
+        fence = null
+      } else {
+        fence.body.push(line)
+      }
+      continue
+    }
+    const fenceStart = /^\s*(```|~~~)/.exec(line)
+    if (fenceStart) {
+      flushBlocks()
+      fence = { marker: fenceStart[1] ?? '```', body: [] }
+      continue
+    }
+    if (!line.trim()) {
+      flushBlocks()
+      continue
+    }
+    const heading = /^(#{1,6})\s+(.*)$/.exec(line)
+    if (heading) {
+      flushBlocks()
+      const level = (heading[1] ?? '#').length
+      out.push(`<h${level}>${inline((heading[2] ?? '').trim())}</h${level}>`)
+      continue
+    }
+    if (/^\s*([-*_])(\s*\1){2,}\s*$/.test(line)) {
+      flushBlocks()
+      out.push('<hr>')
+      continue
+    }
+    // `>` is already escaped by the time this runs.
+    const quoted = /^\s*&gt;\s?(.*)$/.exec(line)
+    if (quoted) {
+      flushParagraph()
+      closeList(out, list)
+      quote.push(quoted[1] ?? '')
+      continue
+    }
+    const bullet = /^\s*[-*+]\s+(.*)$/.exec(line)
+    if (bullet) {
+      flushParagraph()
+      flushQuote()
+      openList(out, list, 'ul')
+      out.push(`<li>${inline(bullet[1] ?? '')}</li>`)
+      continue
+    }
+    const numbered = /^\s*\d+[.)]\s+(.*)$/.exec(line)
+    if (numbered) {
+      flushParagraph()
+      flushQuote()
+      openList(out, list, 'ol')
+      out.push(`<li>${inline(numbered[1] ?? '')}</li>`)
+      continue
+    }
+    flushQuote()
+    closeList(out, list)
+    paragraph.push(line.trim())
+  }
+
+  if (fence) {
+    // An unterminated fence is still content; dropping it would lose the tail
+    // of the document with no sign that anything went missing.
+    out.push(`<pre><code>${fence.body.join('\n')}</code></pre>`)
+  }
+  flushBlocks()
+  return out.join('\n')
+}

--- a/relay-server/src/artifacts/published-page.ts
+++ b/relay-server/src/artifacts/published-page.ts
@@ -1,0 +1,87 @@
+/**
+ * The public half: `GET /a/{slug}` and the chrome a rendered note is served in.
+ *
+ * Separate from the API because the audiences are opposite. Everything the API
+ * does happens for an authenticated account; everything here happens for a
+ * stranger following a link, with no credential and no session, over bytes
+ * somebody else wrote. Keeping the two apart makes it hard to reach for a
+ * session in the one place there is deliberately never going to be one.
+ */
+import type { ServerResponse } from 'node:http'
+import type { ArtifactStore } from './store.js'
+
+/**
+ * Serves a published artifact.
+ *
+ * Unauthenticated on purpose — that is what sharing means — and every header
+ * is about the fact that the body below was written by a stranger. None of
+ * them is the isolation, though: the separate origin is, and these only close
+ * the escapes that survive it.
+ */
+export function servePublishedPage(
+  store: ArtifactStore,
+  rawSlug: string,
+  response: ServerResponse
+): void {
+  const slug = decodeURIComponent(rawSlug)
+  const record = store.find(slug, Date.now())
+  const body = record ? store.readBody(slug) : null
+  if (!record || body === null) {
+    response.writeHead(404, {
+      'content-type': 'text/plain; charset=utf-8',
+      'cache-control': 'no-store',
+      'x-content-type-options': 'nosniff'
+    })
+    response.end('Not found\n')
+    return
+  }
+  response.writeHead(200, {
+    'content-type': 'text/html; charset=utf-8',
+    'content-length': Buffer.byteLength(body),
+    // No caching: an artifact is edited in place and its link does not change,
+    // so a cached copy is how a correction fails to reach anyone.
+    'cache-control': 'no-store',
+    'x-content-type-options': 'nosniff',
+    // Not this origin's to be framed by. An artifact framed inside another page
+    // is a clickjacking surface for whatever that page overlays.
+    'x-frame-options': 'DENY',
+    // The two escapes that survive origin isolation: a form posting the
+    // viewer's input somewhere, and a <base> silently retargeting every link.
+    'content-security-policy': "frame-ancestors 'none'; base-uri 'none'; form-action 'none'",
+    'referrer-policy': 'no-referrer'
+  })
+  response.end(body)
+}
+
+/** Chrome for a rendered markdown page. HTML artifacts are never wrapped. */
+export function wrapDocument(title: string, html: string): string {
+  const safeTitle = title
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${safeTitle}</title>
+<style>
+:root { color-scheme: light dark; }
+body { margin: 0 auto; padding: 2rem 1.25rem 4rem; max-width: 44rem; line-height: 1.7;
+  font: 16px/1.7 -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", sans-serif; }
+pre { overflow-x: auto; padding: 0.75rem 1rem; border-radius: 6px; background: rgba(127,127,127,0.12); }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.92em; }
+pre code { font-size: 0.88em; }
+blockquote { margin: 1rem 0; padding-left: 1rem; border-left: 3px solid rgba(127,127,127,0.35); }
+img { max-width: 100%; }
+table { border-collapse: collapse; }
+hr { border: 0; border-top: 1px solid rgba(127,127,127,0.3); margin: 2rem 0; }
+</style>
+</head>
+<body>
+${html}
+</body>
+</html>
+`
+}

--- a/relay-server/src/artifacts/request-body.ts
+++ b/relay-server/src/artifacts/request-body.ts
@@ -1,0 +1,82 @@
+/**
+ * Reading and validating an artifact write.
+ *
+ * Split out of the handler because it is the one part that touches bytes a
+ * stranger chose, and it is easier to argue about on its own: what shapes are
+ * accepted, what the ceiling is, and what happens to a body that exceeds it.
+ */
+import type { IncomingMessage } from 'node:http'
+import type { ArtifactContentType } from './store.js'
+
+/** Leaves room for JSON escaping over the byte ceiling the desktop enforces. */
+export const REQUEST_OVERHEAD = 1024 * 1024
+
+export type WriteBody = {
+  content: string
+  contentType: ArtifactContentType
+  fileName: string
+  title?: string
+}
+
+function isContentType(value: unknown): value is ArtifactContentType {
+  return value === 'text/html' || value === 'text/markdown'
+}
+
+/**
+ * Reads a body up to the artifact ceiling.
+ *
+ * Not shared/http-json's reader: that one caps at 16 KiB, which is right for a
+ * credential exchange and three orders of magnitude below an artifact.
+ */
+export async function readLargeJson(
+  request: IncomingMessage,
+  limit: number
+): Promise<unknown | null> {
+  const chunks: Buffer[] = []
+  let size = 0
+  try {
+    for await (const chunk of request) {
+      size += (chunk as Buffer).byteLength
+      if (size > limit) {
+        request.destroy()
+        return null
+      }
+      chunks.push(chunk as Buffer)
+    }
+  } catch {
+    return null
+  }
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown
+  } catch {
+    return null
+  }
+}
+
+export function parseWrite(body: unknown, maxBytes: number): WriteBody | { error: string } {
+  if (!body || typeof body !== 'object') {
+    return { error: 'invalid_body' }
+  }
+  const source = body as Record<string, unknown>
+  if (typeof source.content !== 'string' || !isContentType(source.contentType)) {
+    return { error: 'invalid_body' }
+  }
+  if (typeof source.fileName !== 'string' || source.fileName.length > 512) {
+    return { error: 'invalid_body' }
+  }
+  if (
+    source.title !== undefined &&
+    (typeof source.title !== 'string' || source.title.length > 512)
+  ) {
+    return { error: 'invalid_body' }
+  }
+  if (Buffer.byteLength(source.content, 'utf8') > maxBytes) {
+    return { error: 'content_too_large' }
+  }
+  return {
+    content: source.content,
+    contentType: source.contentType,
+    fileName: source.fileName,
+    ...(typeof source.title === 'string' ? { title: source.title } : {})
+  }
+}

--- a/relay-server/src/artifacts/request-body.ts
+++ b/relay-server/src/artifacts/request-body.ts
@@ -27,11 +27,12 @@ function isContentType(value: unknown): value is ArtifactContentType {
  *
  * Not shared/http-json's reader: that one caps at 16 KiB, which is right for a
  * credential exchange and three orders of magnitude below an artifact.
+ *
+ * Returns null for a body that was malformed, cut short, or past the limit —
+ * which parseWrite rejects the same way it rejects any other shape it cannot
+ * use, so the caller has one refusal path rather than two.
  */
-export async function readLargeJson(
-  request: IncomingMessage,
-  limit: number
-): Promise<unknown | null> {
+export async function readLargeJson(request: IncomingMessage, limit: number): Promise<unknown> {
   const chunks: Buffer[] = []
   let size = 0
   try {

--- a/relay-server/src/artifacts/server.ts
+++ b/relay-server/src/artifacts/server.ts
@@ -18,7 +18,9 @@ import type { RateLimiter } from '../shared/rate-limit.js'
 import { json } from '../shared/http-json.js'
 import { rateLimitKey } from '../shared/client-ip.js'
 import { renderMarkdown } from './markdown.js'
-import { type ArtifactContentType, type ArtifactRecord, ArtifactStore } from './store.js'
+import type { ArtifactRecord, ArtifactStore } from './store.js'
+import { servePublishedPage, wrapDocument } from './published-page.js'
+import { parseWrite, readLargeJson, REQUEST_OVERHEAD, type WriteBody } from './request-body.js'
 
 export type ArtifactServerOptions = {
   store: ArtifactStore
@@ -30,76 +32,6 @@ export type ArtifactServerOptions = {
   logger: Logger
   metrics: Metrics
   limiter: RateLimiter
-}
-
-/** Leaves room for JSON escaping over the byte ceiling the desktop enforces. */
-const REQUEST_OVERHEAD = 1024 * 1024
-
-type WriteBody = {
-  content: string
-  contentType: ArtifactContentType
-  fileName: string
-  title?: string
-}
-
-function isContentType(value: unknown): value is ArtifactContentType {
-  return value === 'text/html' || value === 'text/markdown'
-}
-
-/**
- * Reads a body up to the artifact ceiling.
- *
- * Not shared/http-json's reader: that one caps at 16 KiB, which is right for a
- * credential exchange and three orders of magnitude below an artifact.
- */
-async function readLargeJson(request: IncomingMessage, limit: number): Promise<unknown | null> {
-  const chunks: Buffer[] = []
-  let size = 0
-  try {
-    for await (const chunk of request) {
-      size += (chunk as Buffer).byteLength
-      if (size > limit) {
-        request.destroy()
-        return null
-      }
-      chunks.push(chunk as Buffer)
-    }
-  } catch {
-    return null
-  }
-  try {
-    return JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown
-  } catch {
-    return null
-  }
-}
-
-function parseWrite(body: unknown, maxBytes: number): WriteBody | { error: string } {
-  if (!body || typeof body !== 'object') {
-    return { error: 'invalid_body' }
-  }
-  const source = body as Record<string, unknown>
-  if (typeof source.content !== 'string' || !isContentType(source.contentType)) {
-    return { error: 'invalid_body' }
-  }
-  if (typeof source.fileName !== 'string' || source.fileName.length > 512) {
-    return { error: 'invalid_body' }
-  }
-  if (
-    source.title !== undefined &&
-    (typeof source.title !== 'string' || source.title.length > 512)
-  ) {
-    return { error: 'invalid_body' }
-  }
-  if (Buffer.byteLength(source.content, 'utf8') > maxBytes) {
-    return { error: 'content_too_large' }
-  }
-  return {
-    content: source.content,
-    contentType: source.contentType,
-    fileName: source.fileName,
-    ...(typeof source.title === 'string' ? { title: source.title } : {})
-  }
 }
 
 export class ArtifactServer {
@@ -160,7 +92,7 @@ export class ArtifactServer {
     const url = new URL(request.url ?? '/', 'http://artifacts.local')
     const path = url.pathname
     if (path.startsWith('/a/')) {
-      this.serve(path.slice('/a/'.length), response)
+      servePublishedPage(this.options.store, path.slice('/a/'.length), response)
       return true
     }
     if (path !== '/v1/artifacts' && !path.startsWith('/v1/artifacts/')) {
@@ -383,74 +315,4 @@ export class ArtifactServer {
     response.writeHead(204, { 'cache-control': 'no-store' })
     response.end()
   }
-
-  /**
-   * The public link.
-   *
-   * Unauthenticated on purpose — that is what sharing means — and every header
-   * here is about the fact that the bytes below were written by a stranger.
-   */
-  private serve(rawSlug: string, response: ServerResponse): void {
-    const slug = decodeURIComponent(rawSlug)
-    const record = this.options.store.find(slug, Date.now())
-    const body = record ? this.options.store.readBody(slug) : null
-    if (!record || body === null) {
-      response.writeHead(404, {
-        'content-type': 'text/plain; charset=utf-8',
-        'cache-control': 'no-store',
-        'x-content-type-options': 'nosniff'
-      })
-      response.end('Not found\n')
-      return
-    }
-    response.writeHead(200, {
-      'content-type': 'text/html; charset=utf-8',
-      'content-length': Buffer.byteLength(body),
-      // No caching: an artifact is edited in place and its link does not change,
-      // so a cached copy is how a correction fails to reach anyone.
-      'cache-control': 'no-store',
-      'x-content-type-options': 'nosniff',
-      // Not this origin's to be framed by. An artifact framed inside another
-      // page is a clickjacking surface for whatever that page overlays.
-      'x-frame-options': 'DENY',
-      // Cuts the two escapes that survive origin isolation: a form posting the
-      // viewer's input somewhere, and a <base> silently retargeting every link.
-      'content-security-policy': "frame-ancestors 'none'; base-uri 'none'; form-action 'none'",
-      'referrer-policy': 'no-referrer'
-    })
-    response.end(body)
-  }
-}
-
-/** Chrome for a rendered markdown page. HTML artifacts are never wrapped. */
-function wrapDocument(title: string, html: string): string {
-  const safeTitle = title
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-  return `<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>${safeTitle}</title>
-<style>
-:root { color-scheme: light dark; }
-body { margin: 0 auto; padding: 2rem 1.25rem 4rem; max-width: 44rem; line-height: 1.7;
-  font: 16px/1.7 -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", sans-serif; }
-pre { overflow-x: auto; padding: 0.75rem 1rem; border-radius: 6px; background: rgba(127,127,127,0.12); }
-code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.92em; }
-pre code { font-size: 0.88em; }
-blockquote { margin: 1rem 0; padding-left: 1rem; border-left: 3px solid rgba(127,127,127,0.35); }
-img { max-width: 100%; }
-table { border-collapse: collapse; }
-hr { border: 0; border-top: 1px solid rgba(127,127,127,0.3); margin: 2rem 0; }
-</style>
-</head>
-<body>
-${html}
-</body>
-</html>
-`
 }

--- a/relay-server/src/artifacts/server.ts
+++ b/relay-server/src/artifacts/server.ts
@@ -1,0 +1,456 @@
+/**
+ * The artifact API and the pages it publishes.
+ *
+ * Two surfaces with opposite audiences behind one handler: `/v1/artifacts*` is
+ * authenticated and speaks the desktop's contract, `/a/{slug}` is the public
+ * link and is served to anyone. They share a handler because they share a
+ * store; they must not share an origin, which loadConfig refuses to allow.
+ *
+ * The bearer is the same session token the auth server minted, so this checks
+ * it against the same session store. An artifact host that verified its own
+ * credential would be a second identity system for one deployment.
+ */
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { AuthSessionStore } from '../auth/store.js'
+import type { Logger } from '../shared/log.js'
+import type { Metrics } from '../metrics.js'
+import type { RateLimiter } from '../shared/rate-limit.js'
+import { json } from '../shared/http-json.js'
+import { rateLimitKey } from '../shared/client-ip.js'
+import { renderMarkdown } from './markdown.js'
+import { type ArtifactContentType, type ArtifactRecord, ArtifactStore } from './store.js'
+
+export type ArtifactServerOptions = {
+  store: ArtifactStore
+  sessions: AuthSessionStore
+  /** Origin published links point at; never the relay's own. */
+  publicUrl: string
+  maxBytes: number
+  ttlMs: number
+  logger: Logger
+  metrics: Metrics
+  limiter: RateLimiter
+}
+
+/** Leaves room for JSON escaping over the byte ceiling the desktop enforces. */
+const REQUEST_OVERHEAD = 1024 * 1024
+
+type WriteBody = {
+  content: string
+  contentType: ArtifactContentType
+  fileName: string
+  title?: string
+}
+
+function isContentType(value: unknown): value is ArtifactContentType {
+  return value === 'text/html' || value === 'text/markdown'
+}
+
+/**
+ * Reads a body up to the artifact ceiling.
+ *
+ * Not shared/http-json's reader: that one caps at 16 KiB, which is right for a
+ * credential exchange and three orders of magnitude below an artifact.
+ */
+async function readLargeJson(request: IncomingMessage, limit: number): Promise<unknown | null> {
+  const chunks: Buffer[] = []
+  let size = 0
+  try {
+    for await (const chunk of request) {
+      size += (chunk as Buffer).byteLength
+      if (size > limit) {
+        request.destroy()
+        return null
+      }
+      chunks.push(chunk as Buffer)
+    }
+  } catch {
+    return null
+  }
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown
+  } catch {
+    return null
+  }
+}
+
+function parseWrite(body: unknown, maxBytes: number): WriteBody | { error: string } {
+  if (!body || typeof body !== 'object') {
+    return { error: 'invalid_body' }
+  }
+  const source = body as Record<string, unknown>
+  if (typeof source.content !== 'string' || !isContentType(source.contentType)) {
+    return { error: 'invalid_body' }
+  }
+  if (typeof source.fileName !== 'string' || source.fileName.length > 512) {
+    return { error: 'invalid_body' }
+  }
+  if (
+    source.title !== undefined &&
+    (typeof source.title !== 'string' || source.title.length > 512)
+  ) {
+    return { error: 'invalid_body' }
+  }
+  if (Buffer.byteLength(source.content, 'utf8') > maxBytes) {
+    return { error: 'content_too_large' }
+  }
+  return {
+    content: source.content,
+    contentType: source.contentType,
+    fileName: source.fileName,
+    ...(typeof source.title === 'string' ? { title: source.title } : {})
+  }
+}
+
+export class ArtifactServer {
+  constructor(private readonly options: ArtifactServerOptions) {}
+
+  private shareUrl(slug: string): string {
+    return `${this.options.publicUrl}/a/${slug}`
+  }
+
+  /** The wire shape the desktop parses. Field names are its contract, not ours. */
+  private item(record: ArtifactRecord): Record<string, unknown> {
+    return {
+      artifact: {
+        version: 1,
+        slug: record.slug,
+        title: record.title,
+        originalFileName: record.originalFileName,
+        sourceContentType: record.sourceContentType,
+        renderedContentType: 'text/html',
+        createdAt: new Date(record.createdAt).toISOString(),
+        updatedAt: new Date(record.updatedAt).toISOString(),
+        expiresAt: new Date(record.expiresAt).toISOString(),
+        byteSize: record.byteSize,
+        deletedAt: null
+      },
+      shareUrl: this.shareUrl(record.slug)
+    }
+  }
+
+  /** Bearer to account, or null. Same store the auth server writes. */
+  private authenticate(request: IncomingMessage, now: number): string | null {
+    const header = request.headers.authorization
+    if (!header?.startsWith('Bearer ')) {
+      return null
+    }
+    return this.options.sessions.findByAccess(header.slice(7), now)?.accountId ?? null
+  }
+
+  private editToken(request: IncomingMessage): string {
+    const header = request.headers['x-manta-edit-token']
+    return typeof header === 'string' ? header : ''
+  }
+
+  private renderHtml(write: WriteBody): string {
+    // Markdown is rendered to a page this file controls end to end. HTML is
+    // stored as sent: rewriting someone's document is not this server's job,
+    // and the origin — not a filter — is what contains it.
+    return write.contentType === 'text/markdown'
+      ? wrapDocument(write.title ?? write.fileName, renderMarkdown(write.content))
+      : write.content
+  }
+
+  async handle(
+    request: IncomingMessage,
+    response: ServerResponse,
+    clientIp: string
+  ): Promise<boolean> {
+    const url = new URL(request.url ?? '/', 'http://artifacts.local')
+    const path = url.pathname
+    if (path.startsWith('/a/')) {
+      this.serve(path.slice('/a/'.length), response)
+      return true
+    }
+    if (path !== '/v1/artifacts' && !path.startsWith('/v1/artifacts/')) {
+      return false
+    }
+
+    const { logger, metrics, limiter, store } = this.options
+    const decision = limiter.take(`artifacts:${rateLimitKey(clientIp)}`)
+    if (!decision.ok) {
+      metrics.counter('manta_relay_rate_limited_total', 'Requests refused by a rate limiter.', {
+        surface: 'artifacts'
+      })
+      json(
+        response,
+        429,
+        { error: 'rate_limited', code: 'rate_limited' },
+        {
+          'retry-after': String(Math.ceil(decision.retryAfterMs / 1000))
+        }
+      )
+      return true
+    }
+
+    const now = Date.now()
+    const accountId = this.authenticate(request, now)
+    if (!accountId) {
+      json(response, 401, { error: 'unauthorized', code: 'unauthorized' })
+      return true
+    }
+    // Cheap and bounded, and it keeps a listing from showing an artifact whose
+    // link has already stopped working.
+    store.sweep(now)
+
+    const slug = path.startsWith('/v1/artifacts/')
+      ? decodeURIComponent(path.slice('/v1/artifacts/'.length))
+      : ''
+
+    try {
+      if (!slug) {
+        if (request.method === 'GET') {
+          this.listArtifacts(accountId, response, now)
+          return true
+        }
+        if (request.method === 'POST') {
+          await this.createArtifact(request, response, accountId, now)
+          return true
+        }
+        json(
+          response,
+          405,
+          { error: 'method_not_allowed', code: 'method_not_allowed' },
+          {
+            allow: 'GET, POST'
+          }
+        )
+        return true
+      }
+      if (request.method === 'PUT') {
+        await this.updateArtifact(request, response, accountId, slug, now)
+        return true
+      }
+      if (request.method === 'DELETE') {
+        this.deleteArtifact(request, response, accountId, slug, now)
+        return true
+      }
+      json(
+        response,
+        405,
+        { error: 'method_not_allowed', code: 'method_not_allowed' },
+        {
+          allow: 'PUT, DELETE'
+        }
+      )
+      return true
+    } catch (error) {
+      logger.error('artifacts.request_failed', { error, method: request.method ?? '', slug })
+      if (!response.headersSent) {
+        json(response, 500, { error: 'internal_error', code: 'internal_error' })
+      }
+      return true
+    }
+  }
+
+  private listArtifacts(accountId: string, response: ServerResponse, now: number): void {
+    const artifacts = this.options.store.list(accountId, now).map((record) => this.item(record))
+    // No cursor: the per-account cap is two digits, so a page boundary would be
+    // machinery for a case the quota already prevents. nextCursor stays absent,
+    // which the desktop reads as "that was all of them".
+    json(response, 200, { artifacts })
+  }
+
+  private async createArtifact(
+    request: IncomingMessage,
+    response: ServerResponse,
+    accountId: string,
+    now: number
+  ): Promise<void> {
+    const { store, maxBytes, ttlMs, metrics } = this.options
+    const idempotencyKey = (() => {
+      const header = request.headers['idempotency-key']
+      return typeof header === 'string' && header.length <= 200 ? header : null
+    })()
+    if (idempotencyKey) {
+      // The desktop retries a create whose response it never saw, and it needs
+      // the *same* answer — including the edit token, which it then uses to
+      // finish the publish. Anything else and a lost reply becomes either two
+      // artifacts or a publish that can never complete. The token is derived
+      // from the slug, so replaying it costs nothing and stores nothing.
+      const existing = store.findByIdempotencyKey(accountId, idempotencyKey, now)
+      if (existing) {
+        json(response, 200, {
+          ...this.item(existing),
+          editToken: store.editTokenFor(existing.slug)
+        })
+        return
+      }
+    }
+    const body = await readLargeJson(request, maxBytes + REQUEST_OVERHEAD)
+    const write = parseWrite(body, maxBytes)
+    if ('error' in write) {
+      json(response, write.error === 'content_too_large' ? 413 : 400, {
+        error: write.error,
+        code: write.error
+      })
+      return
+    }
+    const quota = store.checkQuota(accountId, Buffer.byteLength(write.content, 'utf8'), now)
+    if (quota) {
+      json(response, 413, { error: quota.reason, code: quota.reason })
+      return
+    }
+    const { record, editToken } = store.create(
+      {
+        accountId,
+        title: write.title ?? null,
+        originalFileName: write.fileName,
+        sourceContentType: write.contentType,
+        byteSize: Buffer.byteLength(write.content, 'utf8'),
+        html: this.renderHtml(write),
+        ttlMs
+      },
+      now,
+      idempotencyKey
+    )
+    metrics.counter('manta_relay_artifacts_total', 'Artifacts published.', { op: 'create' })
+    json(response, 201, { ...this.item(record), editToken })
+  }
+
+  private async updateArtifact(
+    request: IncomingMessage,
+    response: ServerResponse,
+    accountId: string,
+    slug: string,
+    now: number
+  ): Promise<void> {
+    const { store, maxBytes, metrics } = this.options
+    const record = store.find(slug, now)
+    if (!record || record.accountId !== accountId) {
+      json(response, 404, { error: 'artifact_not_found', code: 'artifact_not_found' })
+      return
+    }
+    if (!store.authorizes(record, this.editToken(request))) {
+      json(response, 403, { error: 'forbidden', code: 'forbidden' })
+      return
+    }
+    const body = await readLargeJson(request, maxBytes + REQUEST_OVERHEAD)
+    const write = parseWrite(body, maxBytes)
+    if ('error' in write) {
+      json(response, write.error === 'content_too_large' ? 413 : 400, {
+        error: write.error,
+        code: write.error
+      })
+      return
+    }
+    const byteSize = Buffer.byteLength(write.content, 'utf8')
+    const quota = store.checkQuota(accountId, byteSize, now, record)
+    if (quota) {
+      json(response, 413, { error: quota.reason, code: quota.reason })
+      return
+    }
+    const updated = store.update(
+      record,
+      {
+        title: write.title ?? null,
+        originalFileName: write.fileName,
+        sourceContentType: write.contentType,
+        byteSize,
+        html: this.renderHtml(write)
+      },
+      now
+    )
+    metrics.counter('manta_relay_artifacts_total', 'Artifacts published.', { op: 'update' })
+    json(response, 200, this.item(updated))
+  }
+
+  private deleteArtifact(
+    request: IncomingMessage,
+    response: ServerResponse,
+    accountId: string,
+    slug: string,
+    now: number
+  ): void {
+    const { store, metrics } = this.options
+    const record = store.find(slug, now)
+    if (!record || record.accountId !== accountId) {
+      // The desktop treats exactly this pair as "already gone" and stops
+      // retrying, which is what makes an interrupted unshare converge.
+      json(response, 404, { error: 'artifact_not_found', code: 'artifact_not_found' })
+      return
+    }
+    // An edit token is proof for a caller holding only a link. The owner's
+    // bearer is proof on its own, which is how the app deletes from its list.
+    const provided = this.editToken(request)
+    if (provided && !store.authorizes(record, provided)) {
+      json(response, 403, { error: 'forbidden', code: 'forbidden' })
+      return
+    }
+    store.remove(record)
+    metrics.counter('manta_relay_artifacts_total', 'Artifacts published.', { op: 'delete' })
+    response.writeHead(204, { 'cache-control': 'no-store' })
+    response.end()
+  }
+
+  /**
+   * The public link.
+   *
+   * Unauthenticated on purpose — that is what sharing means — and every header
+   * here is about the fact that the bytes below were written by a stranger.
+   */
+  private serve(rawSlug: string, response: ServerResponse): void {
+    const slug = decodeURIComponent(rawSlug)
+    const record = this.options.store.find(slug, Date.now())
+    const body = record ? this.options.store.readBody(slug) : null
+    if (!record || body === null) {
+      response.writeHead(404, {
+        'content-type': 'text/plain; charset=utf-8',
+        'cache-control': 'no-store',
+        'x-content-type-options': 'nosniff'
+      })
+      response.end('Not found\n')
+      return
+    }
+    response.writeHead(200, {
+      'content-type': 'text/html; charset=utf-8',
+      'content-length': Buffer.byteLength(body),
+      // No caching: an artifact is edited in place and its link does not change,
+      // so a cached copy is how a correction fails to reach anyone.
+      'cache-control': 'no-store',
+      'x-content-type-options': 'nosniff',
+      // Not this origin's to be framed by. An artifact framed inside another
+      // page is a clickjacking surface for whatever that page overlays.
+      'x-frame-options': 'DENY',
+      // Cuts the two escapes that survive origin isolation: a form posting the
+      // viewer's input somewhere, and a <base> silently retargeting every link.
+      'content-security-policy': "frame-ancestors 'none'; base-uri 'none'; form-action 'none'",
+      'referrer-policy': 'no-referrer'
+    })
+    response.end(body)
+  }
+}
+
+/** Chrome for a rendered markdown page. HTML artifacts are never wrapped. */
+function wrapDocument(title: string, html: string): string {
+  const safeTitle = title
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${safeTitle}</title>
+<style>
+:root { color-scheme: light dark; }
+body { margin: 0 auto; padding: 2rem 1.25rem 4rem; max-width: 44rem; line-height: 1.7;
+  font: 16px/1.7 -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", sans-serif; }
+pre { overflow-x: auto; padding: 0.75rem 1rem; border-radius: 6px; background: rgba(127,127,127,0.12); }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.92em; }
+pre code { font-size: 0.88em; }
+blockquote { margin: 1rem 0; padding-left: 1rem; border-left: 3px solid rgba(127,127,127,0.35); }
+img { max-width: 100%; }
+table { border-collapse: collapse; }
+hr { border: 0; border-top: 1px solid rgba(127,127,127,0.3); margin: 2rem 0; }
+</style>
+</head>
+<body>
+${html}
+</body>
+</html>
+`
+}

--- a/relay-server/src/artifacts/store.ts
+++ b/relay-server/src/artifacts/store.ts
@@ -1,0 +1,285 @@
+/**
+ * Artifact metadata and bodies.
+ *
+ * Two stores in one, because they have different failure modes: the index is a
+ * small document that must never be observed half-written (JsonFile handles
+ * that), while a body is up to ten megabytes and has no business in a snapshot
+ * that is rewritten on every mutation. Bodies are files named by slug; the
+ * index is the only thing that says which of them exist.
+ *
+ * The index therefore leads on create and trails on delete: a body with no
+ * index entry is unreachable garbage the sweep collects, whereas an index entry
+ * with no body is a 404 on a link someone has already shared.
+ */
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { JsonFile } from '../shared/json-file.js'
+
+export type ArtifactContentType = 'text/html' | 'text/markdown'
+
+export type ArtifactRecord = {
+  slug: string
+  accountId: string
+  title: string | null
+  originalFileName: string | null
+  sourceContentType: ArtifactContentType
+  createdAt: number
+  updatedAt: number
+  expiresAt: number
+  /** Bytes of the source the publisher sent, which is what its limits count. */
+  byteSize: number
+  /** Ties a replayed create to the artifact the lost response created. */
+  idempotencyKey: string | null
+}
+
+type Snapshot = { v: 1; artifacts: ArtifactRecord[] }
+
+export type ArtifactQuota = {
+  maxPerAccount: number
+  maxTotalBytesPerAccount: number
+}
+
+/** What a create or update needs, minus everything the store decides itself. */
+export type ArtifactWrite = {
+  accountId: string
+  title: string | null
+  originalFileName: string | null
+  sourceContentType: ArtifactContentType
+  byteSize: number
+  html: string
+  ttlMs: number
+}
+
+export type QuotaFailure = { reason: 'too_many' | 'too_large' }
+
+/**
+ * The edit token for a slug, derived rather than stored.
+ *
+ * A create whose response is lost is retried with the same idempotency key, and
+ * the desktop needs the *same* edit token back or it can never finish the
+ * publish — so the token has to be reproducible. Deriving it keeps it out of
+ * the index at rest, which storing it to answer that replay would not.
+ */
+function deriveEditToken(secret: string, slug: string): string {
+  return createHmac('sha256', secret).update(`artifact-edit:${slug}`).digest('base64url')
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const left = Buffer.from(a, 'utf8')
+  const right = Buffer.from(b, 'utf8')
+  return left.byteLength === right.byteLength && timingSafeEqual(left, right)
+}
+
+function wellFormed(record: Partial<ArtifactRecord> | null): boolean {
+  return (
+    typeof record?.slug === 'string' &&
+    typeof record.accountId === 'string' &&
+    typeof record.expiresAt === 'number' &&
+    typeof record.byteSize === 'number'
+  )
+}
+
+export class ArtifactStore {
+  private records: ArtifactRecord[] = []
+  private readonly file: JsonFile<Snapshot>
+  private readonly bodyDir: string | null
+
+  constructor(
+    dataDir: string | null,
+    private readonly onError: (error: Error) => void,
+    private readonly quota: ArtifactQuota,
+    private readonly editSecret: string
+  ) {
+    this.bodyDir = dataDir ? join(dataDir, 'artifacts', 'bodies') : null
+    this.file = new JsonFile<Snapshot>(
+      dataDir ? join(dataDir, 'artifacts', 'index.json') : null,
+      onError
+    )
+    const snapshot = this.file.read()
+    this.records = (snapshot?.artifacts ?? []).filter(wellFormed)
+  }
+
+  get size(): number {
+    return this.records.length
+  }
+
+  get totalBytes(): number {
+    return this.records.reduce((sum, record) => sum + record.byteSize, 0)
+  }
+
+  /**
+   * Live records for an account, newest first.
+   *
+   * Expiry is applied on read rather than only by the sweep, so a link stops
+   * working when it says it does even if nothing has swept yet.
+   */
+  list(accountId: string, now: number): ArtifactRecord[] {
+    return this.records
+      .filter((record) => record.accountId === accountId && record.expiresAt > now)
+      .sort((a, b) => b.createdAt - a.createdAt)
+  }
+
+  find(slug: string, now: number): ArtifactRecord | null {
+    return this.records.find((r) => r.slug === slug && r.expiresAt > now) ?? null
+  }
+
+  findByIdempotencyKey(accountId: string, key: string, now: number): ArtifactRecord | null {
+    return (
+      this.records.find(
+        (r) =>
+          r.accountId === accountId &&
+          r.idempotencyKey !== null &&
+          r.idempotencyKey === key &&
+          r.expiresAt > now
+      ) ?? null
+    )
+  }
+
+  /** The token that authorizes writes to this artifact. */
+  editTokenFor(slug: string): string {
+    return deriveEditToken(this.editSecret, slug)
+  }
+
+  /** True when the caller's token authorizes writes to this record. */
+  authorizes(record: ArtifactRecord, editToken: string): boolean {
+    return constantTimeEqual(this.editTokenFor(record.slug), editToken)
+  }
+
+  /**
+   * Refuses a write that would put the account over its allowance.
+   *
+   * Counted before the body is written, and `replacing` excludes the record an
+   * update is about to overwrite so an edit that shrinks an artifact is never
+   * refused for the space its own older copy occupies.
+   */
+  checkQuota(
+    accountId: string,
+    incomingBytes: number,
+    now: number,
+    replacing?: ArtifactRecord
+  ): QuotaFailure | null {
+    const live = this.list(accountId, now).filter((record) => record !== replacing)
+    if (!replacing && live.length >= this.quota.maxPerAccount) {
+      return { reason: 'too_many' }
+    }
+    const used = live.reduce((sum, record) => sum + record.byteSize, 0)
+    if (used + incomingBytes > this.quota.maxTotalBytesPerAccount) {
+      return { reason: 'too_large' }
+    }
+    return null
+  }
+
+  create(
+    write: ArtifactWrite,
+    now: number,
+    idempotencyKey: string | null
+  ): { record: ArtifactRecord; editToken: string } {
+    const slug = randomBytes(12).toString('base64url')
+    const editToken = this.editTokenFor(slug)
+    const record: ArtifactRecord = {
+      slug,
+      accountId: write.accountId,
+      title: write.title,
+      originalFileName: write.originalFileName,
+      sourceContentType: write.sourceContentType,
+      createdAt: now,
+      updatedAt: now,
+      expiresAt: now + write.ttlMs,
+      byteSize: write.byteSize,
+      idempotencyKey
+    }
+    // Body first: an index entry whose body is missing is a dead link someone
+    // may already have shared, while an orphaned body is collected by the sweep.
+    this.writeBody(slug, write.html)
+    this.records.push(record)
+    this.persist()
+    return { record, editToken }
+  }
+
+  update(
+    record: ArtifactRecord,
+    write: Omit<ArtifactWrite, 'accountId' | 'ttlMs'>,
+    now: number
+  ): ArtifactRecord {
+    this.writeBody(record.slug, write.html)
+    record.title = write.title
+    record.originalFileName = write.originalFileName
+    record.sourceContentType = write.sourceContentType
+    record.byteSize = write.byteSize
+    record.updatedAt = now
+    this.persist()
+    return record
+  }
+
+  remove(record: ArtifactRecord): void {
+    this.records = this.records.filter((candidate) => candidate !== record)
+    this.persist()
+    this.removeBody(record.slug)
+  }
+
+  /** Reads a body, or null when it is missing — a link that outlived its file. */
+  readBody(slug: string): string | null {
+    if (!this.bodyDir) {
+      return this.memory.get(slug) ?? null
+    }
+    try {
+      return readFileSync(join(this.bodyDir, `${slug}.html`), 'utf8')
+    } catch {
+      return null
+    }
+  }
+
+  /** Drops expired records and the bodies that went with them. */
+  sweep(now: number): number {
+    const expired = this.records.filter((record) => record.expiresAt <= now)
+    if (expired.length === 0) {
+      return 0
+    }
+    this.records = this.records.filter((record) => record.expiresAt > now)
+    this.persist()
+    for (const record of expired) {
+      this.removeBody(record.slug)
+    }
+    return expired.length
+  }
+
+  flush(): void {
+    this.file.stop()
+  }
+
+  /** Bodies live in memory when no data directory is configured. */
+  private readonly memory = new Map<string, string>()
+
+  private writeBody(slug: string, html: string): void {
+    if (!this.bodyDir) {
+      this.memory.set(slug, html)
+      return
+    }
+    try {
+      mkdirSync(this.bodyDir, { recursive: true })
+      writeFileSync(join(this.bodyDir, `${slug}.html`), html, { mode: 0o600 })
+    } catch (error) {
+      this.onError(error as Error)
+      throw error
+    }
+  }
+
+  private removeBody(slug: string): void {
+    if (!this.bodyDir) {
+      this.memory.delete(slug)
+      return
+    }
+    try {
+      rmSync(join(this.bodyDir, `${slug}.html`), { force: true })
+    } catch (error) {
+      // A body that will not delete is disk to reclaim later, not a failed
+      // request: the record is already gone and the link already answers 404.
+      this.onError(error as Error)
+    }
+  }
+
+  private persist(): void {
+    this.file.schedule(() => ({ v: 1, artifacts: this.records }))
+  }
+}

--- a/relay-server/src/artifacts/wiring.ts
+++ b/relay-server/src/artifacts/wiring.ts
@@ -1,0 +1,57 @@
+/**
+ * Builds the artifact surface, or nothing at all.
+ *
+ * A factory rather than two constructor calls in the composition root, because
+ * "nothing at all" is the normal case: every deployment that has not asked for
+ * artifacts gets a null here, and the relay behaves exactly as it did before
+ * the feature existed. Keeping that branch in one place is what makes it easy
+ * to see that the off path allocates nothing and serves nothing.
+ */
+import type { RelayConfig } from '../config.js'
+import type { AuthSessionStore } from '../auth/store.js'
+import type { Logger } from '../shared/log.js'
+import type { Metrics } from '../metrics.js'
+import type { RateLimiter } from '../shared/rate-limit.js'
+import { ArtifactServer } from './server.js'
+import { ArtifactStore } from './store.js'
+
+export type ArtifactSurface = {
+  store: ArtifactStore
+  server: ArtifactServer
+}
+
+export function createArtifactSurface(
+  config: RelayConfig,
+  deps: {
+    sessions: AuthSessionStore
+    logger: Logger
+    metrics: Metrics
+    limiter: RateLimiter
+  }
+): ArtifactSurface | null {
+  if (!config.artifacts.enabled) {
+    return null
+  }
+  const store = new ArtifactStore(
+    config.dataDir,
+    (error) => deps.logger.error('artifacts.persist_failed', { error }),
+    {
+      maxPerAccount: config.artifacts.maxPerAccount,
+      maxTotalBytesPerAccount: config.artifacts.maxTotalBytesPerAccount
+    },
+    config.relayTokenSecret
+  )
+  const server = new ArtifactServer({
+    store,
+    // The same sessions the auth server mints: an artifact host that verified
+    // its own credential would be a second identity system for one deployment.
+    sessions: deps.sessions,
+    publicUrl: config.artifacts.publicUrl,
+    maxBytes: config.artifacts.maxBytes,
+    ttlMs: config.artifacts.ttlMs,
+    logger: deps.logger,
+    metrics: deps.metrics,
+    limiter: deps.limiter
+  })
+  return { store, server }
+}

--- a/relay-server/src/config.ts
+++ b/relay-server/src/config.ts
@@ -82,6 +82,20 @@ function registrationMode(hasEnrollmentSecret: boolean): RegistrationMode {
   return 'disabled'
 }
 
+/**
+ * Artifact hosting: off unless an operator turns it on.
+ *
+ * Off by default because enabling it changes what this deployment is. The relay
+ * is a byte pipe that stores credentials and nothing else; artifacts make it a
+ * content host that serves pages, written by whoever publishes them, to anyone
+ * with the link. That is a decision about the operator's disk, their bandwidth,
+ * and their jurisdiction — not something a version bump should make for them.
+ */
+function artifactsEnabled(): boolean {
+  const raw = process.env.MANTA_RELAY_ARTIFACTS?.trim().toLowerCase()
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on'
+}
+
 export type RelayConfig = ReturnType<typeof loadConfig>
 
 /**
@@ -195,6 +209,56 @@ function assertRanges(config: {
   }
 }
 
+/**
+ * Refuses to serve artifacts from the relay's own origin.
+ *
+ * A published artifact is a page its publisher wrote, and it runs with the
+ * privileges of the origin that serves it. Share the relay's origin and that
+ * page can call `/v1/desktop/auth/*` and the cell endpoints as the signed-in
+ * desktop — the isolation *is* the separate origin, so there is no configuration
+ * where reusing one is merely untidy.
+ *
+ * Fatal at startup rather than a warning: the failure it prevents is silent,
+ * and by the time anyone could notice, links have been shared.
+ */
+export function assertArtifactOrigins(config: {
+  artifacts: { enabled: boolean; publicUrl: string }
+  publicUrl: string
+}): void {
+  if (!config.artifacts.enabled) {
+    return
+  }
+  const problems: string[] = []
+  if (!config.artifacts.publicUrl) {
+    problems.push(
+      'MANTA_RELAY_ARTIFACTS_PUBLIC_URL is required when MANTA_RELAY_ARTIFACTS is on; ' +
+        'it is the origin published links point at'
+    )
+  } else {
+    let origin: URL | null = null
+    try {
+      origin = new URL(config.artifacts.publicUrl)
+    } catch {
+      problems.push('MANTA_RELAY_ARTIFACTS_PUBLIC_URL must be a valid URL')
+    }
+    if (origin && (origin.pathname !== '/' || origin.search || origin.hash)) {
+      problems.push(
+        'MANTA_RELAY_ARTIFACTS_PUBLIC_URL must be a bare origin, without a path or query'
+      )
+    }
+    if (origin && origin.origin === new URL(config.publicUrl).origin) {
+      problems.push(
+        'MANTA_RELAY_ARTIFACTS_PUBLIC_URL must not be the relay origin: a published ' +
+          'artifact runs on the origin that serves it and would be able to call the ' +
+          "relay's endpoints as the signed-in desktop"
+      )
+    }
+  }
+  if (problems.length > 0) {
+    throw new Error(`invalid relay configuration:\n  - ${problems.join('\n  - ')}`)
+  }
+}
+
 /** Parses the proxy list here so a typo fails at startup, not on first request. */
 function assertTrustedProxies(spec: string): void {
   try {
@@ -291,9 +355,28 @@ export function loadConfig() {
       controlPerSecond: number('MANTA_RELAY_CONTROL_RATE', 5)
     },
     /** How long connected peers get to migrate before the process exits. */
-    shutdownGraceMs: number('MANTA_RELAY_SHUTDOWN_GRACE_MS', 5_000)
+    shutdownGraceMs: number('MANTA_RELAY_SHUTDOWN_GRACE_MS', 5_000),
+    artifacts: {
+      enabled: artifactsEnabled(),
+      /**
+       * The origin published links point at, and the only origin that serves
+       * them. Must not be the relay's — see assertArtifactOrigins.
+       */
+      publicUrl: (process.env.MANTA_RELAY_ARTIFACTS_PUBLIC_URL?.trim() || '').replace(/\/$/, ''),
+      /** Matches the desktop's own per-artifact ceiling. */
+      maxBytes: number('MANTA_RELAY_ARTIFACTS_MAX_BYTES', 10 * 1024 * 1024),
+      // A link people are given has to outlive the conversation it was shared
+      // in, and the operator is the one paying for the storage until it does.
+      ttlMs: number('MANTA_RELAY_ARTIFACTS_TTL_MS', 30 * 24 * 60 * 60_000),
+      maxPerAccount: number('MANTA_RELAY_ARTIFACTS_MAX_PER_ACCOUNT', 100),
+      maxTotalBytesPerAccount: number(
+        'MANTA_RELAY_ARTIFACTS_MAX_TOTAL_BYTES',
+        256 * 1024 * 1024
+      )
+    }
   }
   assertRanges({ ...config, logLevel })
   assertTrustedProxies(config.trustedProxies)
+  assertArtifactOrigins(config)
   return config
 }

--- a/relay-server/src/main.ts
+++ b/relay-server/src/main.ts
@@ -33,8 +33,19 @@ logger.info('relay.listening', {
   trustedProxies: config.trustedProxies || '(none)',
   metrics: config.metricsToken ? 'enabled' : 'disabled',
   // Deploy-time choice with no other visible signal until something 404s.
-  accounts: config.accountsMode
+  accounts: config.accountsMode,
+  artifacts: config.artifacts.enabled ? config.artifacts.publicUrl : 'disabled'
 })
+
+// Links are the whole point of the feature, and without a data directory they
+// live in memory: every restart 404s every link already handed out.
+if (config.artifacts.enabled && !config.dataDir) {
+  logger.warn('artifacts.no_data_dir', {
+    detail:
+      'artifact hosting is on but MANTA_RELAY_DATA_DIR is unset; published pages are held ' +
+      'in memory and every link breaks on restart. Set a data directory.'
+  })
+}
 
 // Misconfigurations that only show up as a silent pairing failure much later
 // are worth a loud line at startup.

--- a/relay-server/src/relay.ts
+++ b/relay-server/src/relay.ts
@@ -19,8 +19,8 @@ import { RelayAuthServer } from './auth/server.js'
 import { AuthSessionStore } from './auth/store.js'
 import { AccountStore } from './auth/accounts.js'
 import { RelayDirector } from './director/server.js'
-import { ArtifactServer } from './artifacts/server.js'
-import { ArtifactStore } from './artifacts/store.js'
+import type { ArtifactStore } from './artifacts/store.js'
+import { createArtifactSurface } from './artifacts/wiring.js'
 import { RelayCell } from './cell/server.js'
 import { CellStore } from './cell/store.js'
 import { createRelayTokenVerifier } from './shared/relay-token.js'
@@ -126,31 +126,13 @@ export function createRelay(config: RelayConfig, logger = new Logger(config.logL
 
   // Null unless switched on: hosting artifacts turns a byte pipe into a content
   // host, which is the operator's call and not a default.
-  const artifacts = config.artifacts.enabled
-    ? new ArtifactStore(
-        config.dataDir,
-        (error) => logger.error('artifacts.persist_failed', { error }),
-        {
-          maxPerAccount: config.artifacts.maxPerAccount,
-          maxTotalBytesPerAccount: config.artifacts.maxTotalBytesPerAccount
-        },
-        config.relayTokenSecret
-      )
-    : null
-  const artifactServer = artifacts
-    ? new ArtifactServer({
-        store: artifacts,
-        // The same sessions the auth server mints: an artifact host that
-        // verified its own credential would be a second identity system.
-        sessions: authSessions,
-        publicUrl: config.artifacts.publicUrl,
-        maxBytes: config.artifacts.maxBytes,
-        ttlMs: config.artifacts.ttlMs,
-        logger,
-        metrics,
-        limiter: limiters.http
-      })
-    : null
+  const artifactSurface = createArtifactSurface(config, {
+    sessions: authSessions,
+    logger,
+    metrics,
+    limiter: limiters.http
+  })
+  const artifacts = artifactSurface?.store ?? null
 
   const director = new RelayDirector({
     cellUrl: config.publicUrl,
@@ -246,7 +228,7 @@ export function createRelay(config: RelayConfig, logger = new Logger(config.logL
         }
         // Last in the chain: its public surface is a bare `/a/{slug}`, and
         // ahead of the others that prefix would shadow any route they add.
-        if (artifactServer && (await artifactServer.handle(request, response, clientIp))) {
+        if (artifactSurface && (await artifactSurface.server.handle(request, response, clientIp))) {
           return
         }
         json(response, 404, { error: 'not_found' })

--- a/relay-server/src/relay.ts
+++ b/relay-server/src/relay.ts
@@ -19,6 +19,8 @@ import { RelayAuthServer } from './auth/server.js'
 import { AuthSessionStore } from './auth/store.js'
 import { AccountStore } from './auth/accounts.js'
 import { RelayDirector } from './director/server.js'
+import { ArtifactServer } from './artifacts/server.js'
+import { ArtifactStore } from './artifacts/store.js'
 import { RelayCell } from './cell/server.js'
 import { CellStore } from './cell/store.js'
 import { createRelayTokenVerifier } from './shared/relay-token.js'
@@ -39,6 +41,8 @@ export type Relay = {
   store: CellStore
   accounts: AccountStore
   authSessions: AuthSessionStore
+  /** Null unless artifact hosting is switched on. */
+  artifacts: ArtifactStore | null
   logger: Logger
   metrics: Metrics
   listen: () => Promise<number>
@@ -120,6 +124,34 @@ export function createRelay(config: RelayConfig, logger = new Logger(config.logL
     ...(config.enrollmentSecret ? { enrollmentSecret: config.enrollmentSecret } : {})
   })
 
+  // Null unless switched on: hosting artifacts turns a byte pipe into a content
+  // host, which is the operator's call and not a default.
+  const artifacts = config.artifacts.enabled
+    ? new ArtifactStore(
+        config.dataDir,
+        (error) => logger.error('artifacts.persist_failed', { error }),
+        {
+          maxPerAccount: config.artifacts.maxPerAccount,
+          maxTotalBytesPerAccount: config.artifacts.maxTotalBytesPerAccount
+        },
+        config.relayTokenSecret
+      )
+    : null
+  const artifactServer = artifacts
+    ? new ArtifactServer({
+        store: artifacts,
+        // The same sessions the auth server mints: an artifact host that
+        // verified its own credential would be a second identity system.
+        sessions: authSessions,
+        publicUrl: config.artifacts.publicUrl,
+        maxBytes: config.artifacts.maxBytes,
+        ttlMs: config.artifacts.ttlMs,
+        logger,
+        metrics,
+        limiter: limiters.http
+      })
+    : null
+
   const director = new RelayDirector({
     cellUrl: config.publicUrl,
     assignmentEpoch: config.assignmentEpoch,
@@ -187,6 +219,16 @@ export function createRelay(config: RelayConfig, logger = new Logger(config.logL
           )
           metrics.gauge('manta_relay_auth_sessions', 'Stored auth sessions.', authSessions.size)
           metrics.gauge('manta_relay_accounts', 'Registered accounts.', accounts.size)
+          if (artifacts) {
+            // The operator's disk is the thing at stake, so the byte total
+            // matters as much as the count.
+            metrics.gauge('manta_relay_artifacts', 'Stored artifacts.', artifacts.size)
+            metrics.gauge(
+              'manta_relay_artifact_bytes',
+              'Bytes of artifact content held.',
+              artifacts.totalBytes
+            )
+          }
           const body = metrics.render()
           response.writeHead(200, {
             'content-type': 'text/plain; version=0.0.4',
@@ -200,6 +242,11 @@ export function createRelay(config: RelayConfig, logger = new Logger(config.logL
           return
         }
         if (await director.handle(request, response, clientIp)) {
+          return
+        }
+        // Last in the chain: its public surface is a bare `/a/{slug}`, and
+        // ahead of the others that prefix would shadow any route they add.
+        if (artifactServer && (await artifactServer.handle(request, response, clientIp))) {
           return
         }
         json(response, 404, { error: 'not_found' })
@@ -293,6 +340,7 @@ export function createRelay(config: RelayConfig, logger = new Logger(config.logL
     store,
     accounts,
     authSessions,
+    artifacts,
     logger,
     metrics,
     listen: () =>
@@ -319,6 +367,7 @@ export function createRelay(config: RelayConfig, logger = new Logger(config.logL
       store.flush()
       authSessions.flush()
       accounts.flush()
+      artifacts?.flush()
       // Tell peers, then give them the grace window to migrate. Phones need an
       // explicit 4503; a bare socket close reaches them as 1006, which their
       // close-code table treats as a generic transport failure.
@@ -349,6 +398,7 @@ export function createRelay(config: RelayConfig, logger = new Logger(config.logL
       store.flush()
       authSessions.flush()
       accounts.flush()
+      artifacts?.flush()
       logger.info('relay.stopped', { reason })
     }
   }

--- a/relay-server/src/testing/harness.ts
+++ b/relay-server/src/testing/harness.ts
@@ -81,9 +81,25 @@ export function testConfig(port: number, overrides: Partial<RelayConfig> = {}): 
       controlBurst: 1_000,
       controlPerSecond: 100
     },
-    shutdownGraceMs: 50
+    shutdownGraceMs: 50,
+    // Off by default here for the same reason it is off in production: every
+    // suite that does not ask for artifacts should exercise a relay without
+    // them, so the feature cannot quietly become load-bearing elsewhere.
+    artifacts: {
+      enabled: false,
+      publicUrl: '',
+      maxBytes: 10 * 1024 * 1024,
+      ttlMs: 30 * 24 * 60 * 60_000,
+      maxPerAccount: 100,
+      maxTotalBytesPerAccount: 256 * 1024 * 1024
+    }
   }
-  return { ...base, ...overrides, limits: { ...base.limits, ...overrides.limits } }
+  return {
+    ...base,
+    ...overrides,
+    limits: { ...base.limits, ...overrides.limits },
+    artifacts: { ...base.artifacts, ...overrides.artifacts }
+  }
 }
 
 export type TestRelay = {

--- a/src/main/artifacts/artifact-cloud-config.test.ts
+++ b/src/main/artifacts/artifact-cloud-config.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  resetMantaCloudEndpointOverrideSourceForTests,
+  setMantaCloudEndpointOverrideSource
+} from '../manta-profiles/profile-cloud-auth-config'
 import {
   allowsArtifactCloudAuthOverride,
   resolveArtifactCloudApiUrl
@@ -92,5 +96,48 @@ describe('allowsArtifactCloudAuthOverride', () => {
     expect(allowsArtifactCloudAuthOverride({ NODE_ENV: 'production' }, false)).toBe(false)
     expect(allowsArtifactCloudAuthOverride(DEV, true)).toBe(false)
     expect(allowsArtifactCloudAuthOverride(DEV, false)).toBe(true)
+  })
+})
+
+describe('resolveArtifactCloudApiUrl with a configured artifact host', () => {
+  afterEach(() => {
+    resetMantaCloudEndpointOverrideSourceForTests()
+  })
+
+  it('prefers the settings field over the environment variable', () => {
+    // The variable only reaches a build launched from a shell; a packaged app
+    // started from the Dock inherits none, which is why the field outranks it.
+    setMantaCloudEndpointOverrideSource(() => ({ artifactsBaseUrl: 'https://share.example.com' }))
+    expect(
+      resolveArtifactCloudApiUrl(undefined, { MANTA_ARTIFACTS_API_URL: 'https://env.example' }, true)
+    ).toBe('https://share.example.com')
+  })
+
+  it('falls back to the variable, then the built-in host, as the field empties', () => {
+    setMantaCloudEndpointOverrideSource(() => ({}))
+    expect(
+      resolveArtifactCloudApiUrl(undefined, { MANTA_ARTIFACTS_API_URL: 'https://env.example' }, true)
+    ).toBe('https://env.example')
+    expect(resolveArtifactCloudApiUrl(undefined, {}, true)).toBe('https://share.manta.sh.cn')
+  })
+
+  it('makes the configured host the allow-list a per-call override must match', () => {
+    // The point of the allow-list: apiUrl is a per-call parameter reachable from
+    // anything that can run one command, while the bearer comes from the stored
+    // session. A field-configured host must bind it just as the variable does.
+    setMantaCloudEndpointOverrideSource(() => ({ artifactsBaseUrl: 'https://share.example.com' }))
+    expect(resolveArtifactCloudApiUrl('https://share.example.com', {}, true)).toBe(
+      'https://share.example.com'
+    )
+    expect(() => resolveArtifactCloudApiUrl('https://evil.example', {}, true)).toThrow(
+      /only in development/
+    )
+  })
+
+  it('survives a reader that throws rather than making publishing unusable', () => {
+    setMantaCloudEndpointOverrideSource(() => {
+      throw new Error('settings unreadable')
+    })
+    expect(resolveArtifactCloudApiUrl(undefined, {}, true)).toBe('https://share.manta.sh.cn')
   })
 })

--- a/src/main/artifacts/artifact-cloud-config.ts
+++ b/src/main/artifacts/artifact-cloud-config.ts
@@ -1,4 +1,5 @@
 import { app } from 'electron'
+import { getMantaCloudEndpointOverrides } from '../manta-profiles/profile-cloud-auth-config'
 
 const PRODUCTION_ARTIFACTS_API_URL = 'https://share.manta.sh.cn'
 
@@ -28,6 +29,22 @@ function validateArtifactOrigin(candidate: string, packaged: boolean): string {
 }
 
 /**
+ * The operator's artifact host, from settings.
+ *
+ * Swallows a failure on purpose: the reader runs against live settings, and a
+ * publish must not become unusable because the stored value is unreadable —
+ * the caller falls through to the variable and then the built-in default, and
+ * validateArtifactOrigin still has the last word over whatever it lands on.
+ */
+function settingsArtifactsOrigin(): string {
+  try {
+    return getMantaCloudEndpointOverrides()?.artifactsBaseUrl?.trim() ?? ''
+  } catch {
+    return ''
+  }
+}
+
+/**
  * The one origin a Manta access token is allowed to reach.
  *
  * Upstream hardcoded its own domain here. This fork runs no artifact service,
@@ -39,10 +56,16 @@ function validateArtifactOrigin(candidate: string, packaged: boolean): string {
  * a prompt-injected session, a script in the repo — could send that token to a
  * host of its choosing without needing publish permission at all.
  *
- * So the allow-list stays; the operator just owns it now. MANTA_ARTIFACTS_API_URL
+ * So the allow-list stays; the operator just owns it now. The settings field
  * names the host, and a per-call override has to agree with it. Development
  * builds keep the free-form override, gated exactly like the authToken override
  * next to it.
+ *
+ * Why the setting outranks MANTA_ARTIFACTS_API_URL: the variable is only
+ * reachable by a build launched from a shell, and a packaged app started from
+ * the Dock or Explorer inherits no environment at all — so for the people this
+ * feature exists for it was never settable. The variable stays as the way to
+ * pin a host for a dev build or a headless server, which is where it works.
  */
 export function resolveArtifactCloudApiUrl(
   override?: string,
@@ -50,7 +73,7 @@ export function resolveArtifactCloudApiUrl(
   packaged = isPackaged()
 ): string {
   const configured = validateArtifactOrigin(
-    env.MANTA_ARTIFACTS_API_URL?.trim() || PRODUCTION_ARTIFACTS_API_URL,
+    settingsArtifactsOrigin() || env.MANTA_ARTIFACTS_API_URL?.trim() || PRODUCTION_ARTIFACTS_API_URL,
     packaged
   )
   const candidate = override?.trim()

--- a/src/main/manta-profiles/profile-cloud-auth-config.ts
+++ b/src/main/manta-profiles/profile-cloud-auth-config.ts
@@ -17,6 +17,18 @@ export function resetMantaCloudEndpointOverrideSourceForTests(): void {
   readEndpointOverrides = () => null
 }
 
+/**
+ * The stored overrides, for the one consumer that is not an auth endpoint.
+ *
+ * Artifact publishing needs the operator's host and cannot read the store
+ * itself (store.ts already depends on manta-profiles), so it borrows the reader
+ * installed here rather than growing a second injection point that could drift
+ * out of step with this one.
+ */
+export function getMantaCloudEndpointOverrides(): MantaCloudEndpointOverrides | null {
+  return readEndpointOverrides()
+}
+
 export type MantaCloudAuthConfig = {
   apiBaseUrl: string
   authorizeEndpoint: string

--- a/src/renderer/src/components/artifacts/ArtifactsSelfHostNotice.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactsSelfHostNotice.tsx
@@ -6,9 +6,10 @@ import { translate } from '@/i18n/i18n'
  * user hits by default is a network error against a domain nobody serves, with
  * nothing on screen to explain why.
  *
- * Deliberately stated rather than derived: the API origin is chosen in the main
- * process from an env var with no IPC to the renderer, and the sentence below is
- * true whether or not that var is set.
+ * Deliberately stated rather than derived: the origin is resolved in the main
+ * process, and the sentence below is true whether or not it has been set. It
+ * names where to set it, because the answer used to be an environment variable
+ * a packaged app never sees.
  */
 export function ArtifactsSelfHostNotice({
   className = ''
@@ -21,7 +22,7 @@ export function ArtifactsSelfHostNotice({
     >
       {translate(
         'auto.components.artifacts.ArtifactsSelfHostNotice.body',
-        'This self-hosted build ships no artifact service. Publishing uploads to whatever MANTA_ARTIFACTS_API_URL points at; leave it unset and links are created against a host this fork does not run, so the upload fails. Run your own and set the variable, or keep sharing off.'
+        'This build ships no artifact service of its own. Publishing goes to the artifact host set under Manta Cloud → Configure endpoints; leave it empty and links are created against a host nobody runs, so the upload fails. A self-hosted relay can serve one — see its README — or keep sharing off.'
       )}
     </div>
   )

--- a/src/renderer/src/components/settings/MantaCloudEndpointsSection.test.tsx
+++ b/src/renderer/src/components/settings/MantaCloudEndpointsSection.test.tsx
@@ -67,6 +67,7 @@ describe('MantaCloudEndpointsSection', () => {
     const draft = {
       apiBaseUrl: 'https://relay.example.com',
       relayDirectorUrl: 'https://relay.example.com',
+      artifactsBaseUrl: '',
       clientId: 'manta-desktop',
       enrollmentSecret: ''
     }
@@ -81,10 +82,47 @@ describe('MantaCloudEndpointsSection', () => {
 
     // Clearing every field is still a real "use the official endpoints" action.
     const cleared = validateMantaCloudEndpointsDraft(
-      { apiBaseUrl: '', relayDirectorUrl: '', clientId: '', enrollmentSecret: '' },
+      { apiBaseUrl: '', relayDirectorUrl: '', artifactsBaseUrl: '', clientId: '', enrollmentSecret: '' },
       'already-stored'
     )
     expect(cleared.ok && cleared.value).toBeUndefined()
+  })
+
+  it('refuses an artifact host that shares the relay origin', () => {
+    // A shared artifact is a page someone else wrote and it runs on whatever
+    // origin serves it, so the same origin as the relay lets that page call the
+    // relay as the signed-in desktop. Refused here as well as on the relay so
+    // the person finds out while typing.
+    const clash = validateMantaCloudEndpointsDraft({
+      apiBaseUrl: 'https://relay.example.com',
+      relayDirectorUrl: 'https://relay.example.com',
+      artifactsBaseUrl: 'https://relay.example.com',
+      clientId: '',
+      enrollmentSecret: ''
+    })
+    expect(clash.ok).toBe(false)
+
+    const separate = validateMantaCloudEndpointsDraft({
+      apiBaseUrl: 'https://relay.example.com',
+      relayDirectorUrl: 'https://relay.example.com',
+      artifactsBaseUrl: 'https://share.example.com',
+      clientId: '',
+      enrollmentSecret: ''
+    })
+    expect(separate.ok && separate.value?.artifactsBaseUrl).toBe('https://share.example.com')
+  })
+
+  it('lets an artifact host stand alone, without a self-hosted relay', () => {
+    // Pointing at someone else's artifact host is independent of where sign-in
+    // and the relay live, so it must not trip the api/relay pairing rule.
+    const alone = validateMantaCloudEndpointsDraft({
+      apiBaseUrl: '',
+      relayDirectorUrl: '',
+      artifactsBaseUrl: 'https://share.example.com',
+      clientId: '',
+      enrollmentSecret: ''
+    })
+    expect(alone.ok && alone.value?.artifactsBaseUrl).toBe('https://share.example.com')
   })
 
   it('reveals the section when any endpoint is already configured', () => {

--- a/src/renderer/src/components/settings/MantaCloudEndpointsSection.tsx
+++ b/src/renderer/src/components/settings/MantaCloudEndpointsSection.tsx
@@ -33,6 +33,7 @@ export function hasConfiguredMantaCloudEndpoints(settings: GlobalSettings): bool
   return Boolean(
     endpoints?.apiBaseUrl ||
     endpoints?.relayDirectorUrl ||
+    endpoints?.artifactsBaseUrl ||
     endpoints?.clientId ||
     endpoints?.enrollmentSecret
   )
@@ -41,6 +42,7 @@ export function hasConfiguredMantaCloudEndpoints(settings: GlobalSettings): bool
 export type MantaCloudEndpointsDraft = {
   apiBaseUrl: string
   relayDirectorUrl: string
+  artifactsBaseUrl: string
   clientId: string
   enrollmentSecret: string
 }
@@ -51,6 +53,7 @@ export function createMantaCloudEndpointsDraft(
   return {
     apiBaseUrl: overrides?.apiBaseUrl ?? '',
     relayDirectorUrl: overrides?.relayDirectorUrl ?? '',
+    artifactsBaseUrl: overrides?.artifactsBaseUrl ?? '',
     clientId: overrides?.clientId ?? '',
     // Deliberately not prefilled: a stored secret would then sit in the DOM as
     // an input value on every settings render. Empty means "leave it alone".
@@ -82,6 +85,24 @@ export function validateMantaCloudEndpointsDraft(
   if (!relay.ok) {
     return { ok: false, message: relay.message }
   }
+  const artifacts = normalizeMantaCloudOrigin(draft.artifactsBaseUrl)
+  if (!artifacts.ok) {
+    return { ok: false, message: artifacts.message }
+  }
+  // Why refused rather than merely discouraged: a shared artifact is a page
+  // someone else wrote, and it runs on whatever origin serves it. Same origin
+  // as the relay and that page can call the relay's endpoints as the signed-in
+  // desktop. The relay refuses this too; catching it here means the person
+  // finds out while typing rather than from a publish that fails later.
+  if (artifacts.value && relay.value && artifacts.value === relay.value) {
+    return {
+      ok: false,
+      message: translate(
+        'auto.components.settings.MantaCloudEndpointsSection.artifactsOriginShared',
+        'The artifact host must be a different origin from the relay address.'
+      )
+    }
+  }
   const enrollmentSecret = normalizeMantaCloudEnrollmentSecret(draft.enrollmentSecret)
   if (!enrollmentSecret.ok) {
     return { ok: false, message: enrollmentSecret.message }
@@ -101,7 +122,13 @@ export function validateMantaCloudEndpointsDraft(
   }
   // Everything blank means "go back to the official endpoints" — including the
   // secret, which is why a saved one is not carried forward here.
-  if (!api.value && !relay.value && !clientId.value && !enrollmentSecret.value) {
+  if (
+    !api.value &&
+    !relay.value &&
+    !artifacts.value &&
+    !clientId.value &&
+    !enrollmentSecret.value
+  ) {
     return { ok: true, value: undefined }
   }
   const secret = enrollmentSecret.value || (savedSecret ?? '')
@@ -111,6 +138,9 @@ export function validateMantaCloudEndpointsDraft(
   }
   if (relay.value) {
     next.relayDirectorUrl = relay.value
+  }
+  if (artifacts.value) {
+    next.artifactsBaseUrl = artifacts.value
   }
   if (clientId.value) {
     next.clientId = clientId.value
@@ -240,6 +270,15 @@ export function MantaCloudEndpointsSection({
                 'Relay address'
               ),
               'https://relay.example.com'
+            )}
+            {field(
+              'artifactsBaseUrl',
+              'settings-manta-cloud-artifacts',
+              translate(
+                'auto.components.settings.MantaCloudEndpointsSection.artifactsLabel',
+                'Artifact host'
+              ),
+              'https://share.example.com'
             )}
             {field(
               'clientId',

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11835,7 +11835,9 @@
           "enrollmentPlaceholder": "Only if your relay requires one",
           "warning": "Both addresses must use https with a certificate your phone trusts. The relay only forwards end-to-end encrypted data, but its operator can see who connects and when. Applying signs you out and restarts Manta.",
           "applying": "Restarting…",
-          "apply": "Apply and restart"
+          "apply": "Apply and restart",
+          "artifactsOriginShared": "The artifact host must be a different origin from the relay address.",
+          "artifactsLabel": "Artifact host"
         },
         "relayMachines": {
           "unnamed": "Unnamed machine",
@@ -16859,7 +16861,7 @@
         "typeMarkdown": "Markdown",
         "typeHtml": "HTML",
         "ArtifactsSelfHostNotice": {
-          "body": "This self-hosted build ships no artifact service. Publishing uploads to whatever MANTA_ARTIFACTS_API_URL points at; leave it unset and links are created against a host this fork does not run, so the upload fails. Run your own and set the variable, or keep sharing off."
+          "body": "This build ships no artifact service of its own. Publishing goes to the artifact host set under Manta Cloud → Configure endpoints; leave it empty and links are created against a host nobody runs, so the upload fails. A self-hosted relay can serve one — see its README — or keep sharing off."
         }
       },
       "BrowserCookieImportMachineNotice": {

--- a/src/shared/manta-cloud-endpoints.ts
+++ b/src/shared/manta-cloud-endpoints.ts
@@ -14,6 +14,15 @@ export type MantaCloudEndpointOverrides = {
   authBaseUrl?: string
   /** Relay director origin. Must be a bare origin (no path/query/hash). */
   relayDirectorUrl?: string
+  /**
+   * Artifact host origin. Bare origin, and deliberately not derived from the
+   * relay's: the pages it serves are authored by whoever publishes them and run
+   * on whatever origin serves them, so sharing one with the relay would let a
+   * published page script against the relay's endpoints as the signed-in user.
+   * Empty leaves sharing pointed at the built-in host, which a self-hosted
+   * build does not run.
+   */
+  artifactsBaseUrl?: string
   /** OAuth client id registered with the self-hosted auth server. */
   clientId?: string
   /**
@@ -170,6 +179,10 @@ export function normalizeMantaCloudEndpointOverrides(
   const relayDirectorUrl = normalizeMantaCloudOrigin(source.relayDirectorUrl, options)
   if (relayDirectorUrl.ok && relayDirectorUrl.value) {
     next.relayDirectorUrl = relayDirectorUrl.value
+  }
+  const artifactsBaseUrl = normalizeMantaCloudOrigin(source.artifactsBaseUrl, options)
+  if (artifactsBaseUrl.ok && artifactsBaseUrl.value) {
+    next.artifactsBaseUrl = artifactsBaseUrl.value
   }
   const enrollmentSecret = normalizeMantaCloudEnrollmentSecret(source.enrollmentSecret)
   if (enrollmentSecret.ok && enrollmentSecret.value) {


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​591 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​589 |
| Prod | 20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1420 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1406 |

<!-- /manta-pr-loc -->

Sharing a file as a link needs a host to serve the page. This fork runs none, so
the feature has been dead by default: the endpoint was configurable, but it
pointed at a domain nobody answers.

## The desktop half

An **Artifact host** field beside the other Manta Cloud endpoints.

It was already settable through `MANTA_ARTIFACTS_API_URL` — which a packaged app
launched from the Dock or Explorer never sees. For the people this feature exists
for, it was never settable at all. The field outranks the variable; the variable
stays for dev builds and headless servers, where it does work.

The per-call allow-list is unchanged and now binds to whichever source won.
That check is load-bearing: `apiUrl` is a parameter anything able to run one
command can set, while the bearer comes from the stored session and is not bound
to it.

## The relay half

Artifact hosting, **off unless switched on**, gated like accounts mode:

```bash
MANTA_RELAY_ARTIFACTS=1
MANTA_RELAY_ARTIFACTS_PUBLIC_URL=https://share.example.com
```

Enabling it changes what a deployment is. Everywhere else the relay is a byte
pipe that stores credentials and forwards frames it cannot read; artifacts make
it a content host that keeps pages, written by whoever published them, and
serves them to anyone with the link. So it takes an explicit flag and an
explicit origin, and it ships with quotas and a TTL — the relay can bound how
much people publish, never what.

`GET /v1/artifacts`, `POST`, `PUT /{slug}`, `DELETE /{slug}`, and the public
`GET /a/{slug}`. The shape is the desktop's contract, not a new one.

### The artifact origin must not be the relay origin

The relay refuses to start if they match, and the settings field refuses the
same clash while the person is still typing.

A published page runs with the privileges of whatever origin serves it. Share
the relay's and that page can call `/v1/desktop/auth/*` and the cell endpoints
as the signed-in desktop, from the viewer's browser. **The separate origin is
the isolation** — not the CSP, not the sandbox headers, not the escaping. That
is why it is fatal rather than discouraged.

### Markdown without a sanitizer

Rendered by a small renderer here rather than a parser plus a sanitizer. This
process holds account credentials and its whole dependency surface is two
packages; a sanitizer would be the largest thing in it *and* load-bearing, and
one bypass turns a shared note into script on the artifact origin.

Escaping every byte first and then building a fixed set of tags removes that
class of bug instead of filtering it — the only tags in the output are ones the
renderer wrote. Raw HTML in a markdown source shows as text, which is a
documented limitation.

HTML artifacts are served verbatim. That is the feature working, and the reason
the origin rule above is not negotiable.

### Identity and replay

Authentication is the session the auth server already mints, checked against the
same store: an artifact host verifying its own credential would be a second
identity system for one deployment.

The edit token is derived from the slug rather than stored, so a create whose
response was lost can be retried with its idempotency key and get the *same*
token back — which is exactly what the desktop needs to finish that publish.
Anything else and a dropped reply becomes two artifacts or a publish that can
never complete.

## Verification

- relay: 233 tests, including 19 new ones driving the surface over real HTTP —
  the status codes the desktop branches on, the headers the public page carries,
  cross-account isolation, quotas, expiry, and survival across a restart.
- markdown: 15 tests, most of them attempts to get a tag out of it.
- desktop: `pnpm tc` clean; the endpoint and settings suites pass.
- Off by default, and the harness leaves it off, so every existing suite still
  exercises a relay without it.