### PR TITLE
i18n(zh): translate the self-hosted server pane

### DIFF
--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10331,6 +10331,24 @@
           "saveFailed": "无法保存可见性默认设置。",
           "updateServer": "请更新此服务器以配置来源默认设置。",
           "updateServerDefaults": "请更新此服务器以配置可见性默认设置。"
+        },
+        "MantaCloudEndpointsSection": {
+          "title": "自建服务器",
+          "description": "把登录和手机中继指向你自己的服务器，而不是官方的。",
+          "configure": "配置端点",
+          "apiLabel": "登录服务器",
+          "relayLabel": "中继地址",
+          "artifactsLabel": "Artifact 主机",
+          "clientIdLabel": "OAuth 客户端 ID",
+          "enrollmentLabel": "注册密钥",
+          "enrollmentSaved": "已保存 — 输入即可替换",
+          "enrollmentPlaceholder": "仅当你的中继要求时填写",
+          "pairRequired": "登录服务器和中继地址要一起填，或者都留空。",
+          "artifactsOriginShared": "Artifact 主机必须与中继地址使用不同的源。",
+          "warning": "两个地址都必须使用 https，且证书须为你的手机所信任。中继只转发端到端加密的数据，但它的运营者能看到谁在何时连接。应用后会退出登录并重启 Manta。",
+          "applying": "正在重启…",
+          "apply": "应用并重启",
+          "applyFailed": "无法应用这些端点。请检查填写的值后重试。"
         }
       },
       "right": {
@@ -14539,6 +14557,9 @@
           "deleteTitle": "删除工件？",
           "deleteDescription": "“{{name}}” 将无法再通过其公共链接访问。",
           "delete": "删除"
+        },
+        "ArtifactsSelfHostNotice": {
+          "body": "此版本不自带 artifact 服务。发布会上传到「自建服务器 → 配置端点」中设置的 Artifact 主机；留空则链接指向一台无人提供服务的主机，上传会失败。自建中继可以提供该服务（见其 README），也可以就不用分享功能。"
         }
       },
       "ComposerParentWorktreePicker": {


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 |

<!-- /manta-pr-loc -->

The pane had no Chinese entries at all. A zh user pointing Manta at their own
relay read the entire dialog in English — including the warning that its
operator can see who connects and when, which is the one sentence in there
worth being sure someone understood.

Sixteen entries, plus the artifact notice that sends people to this pane and
named it in English while doing so.

Terminology follows the catalog's existing choices: 中继 for relay, 登录 for
sign-in, 端点 for endpoint. Artifact stays as-is — it is the name of the thing
in the URL and in the relay's own configuration, so translating it would make
the setting harder to match up with what it configures.

zh coverage 12098 → 12115. `fork-zh-terminology --check` clean.