### PR TITLE
chore(release): cut 1.4.197-rc.1

### DIFF
--- a/docs/release-notes/1.4.197-rc.1.md
+++ b/docs/release-notes/1.4.197-rc.1.md
@@ -1,0 +1,10 @@
+# 1.4.197-rc.1
+
+Fork-only; upstream is unchanged since 1.4.197-rc.0. The phone app is unchanged too.
+
+- Sharing a file as a link can now point at a self-hosted relay, which can serve
+  the pages itself. Off unless its operator turns it on.
+- The artifact host is a settings field — Self-hosted server → Configure
+  endpoints. It was an environment variable a packaged app never saw.
+- That whole pane is in Chinese now, including the warning about what a relay
+  operator can see.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta",
-  "version": "1.4.197-rc.0",
+  "version": "1.4.197-rc.1",
   "description": "Next-gen IDE for parallel agentic development",
   "homepage": "https://github.com/paidaxingyo666/Manta",
   "author": "Manta",

--- a/resources/skills/release-mapping.json
+++ b/resources/skills/release-mapping.json
@@ -665,6 +665,19 @@
         "manta-per-workspace-env": 6,
         "orchestration": 30
       }
+    },
+    {
+      "appVersion": "1.4.197-rc.1",
+      "skills": {
+        "computer-use": 10,
+        "linear-tickets": 11,
+        "manta-cli": 39,
+        "manta-emulator": 8,
+        "manta-emulator-android": 6,
+        "manta-linear": 9,
+        "manta-per-workspace-env": 6,
+        "orchestration": 31
+      }
     }
   ]
 }


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |

<!-- /manta-pr-loc -->

Fork-only. Upstream has not moved since 1.4.197-rc.0, and the phone app is
unchanged, so this tags the desktop line alone.

What is in it:

- **Artifact hosting for a self-hosted relay.** Sharing a file as a link needed
  a host to serve the page, and this fork ran none — the endpoint was
  configurable but pointed at a domain nobody answers. A relay can now be that
  host, off unless its operator turns it on and names a separate origin for it.
- **The artifact host is a settings field.** It was only ever an environment
  variable, which a packaged app launched from the Dock or Explorer never sees,
  so for the people the feature exists for it was not settable at all.
- **The self-hosted server pane is translated.** It had no Chinese entries, so a
  zh user configuring their own relay read the whole dialog in English —
  including the warning about what its operator can see.

Notes rewritten over the generated draft: that draft counted the split and a
type cleanup from the same feature as two separate relay "fixes", which is true
of the commit range and misleading to someone deciding whether to update.

Merging tags `v1.4.197-rc.1` and starts the desktop builds.