### PR TITLE
fix(cloud): stop discarding the error the relay just named

### DIFF
--- a/src/main/manta-profiles/profile-cloud-client.test.ts
+++ b/src/main/manta-profiles/profile-cloud-client.test.ts
@@ -354,3 +354,56 @@ describe('direct grant', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 })
+
+describe('failure bodies name what went wrong', () => {
+  it('carries the relay error code out of a 409 so callers can explain it', async () => {
+    // A per-user relay refuses the direct grant with 'accounts_required', and
+    // profile-cloud-service turns that into "sign in from Settings → Manta
+    // Account". Discarding the body made that mapping unreachable and left the
+    // person with `manta_cloud_request_failed_409`.
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'accounts_required' }), {
+        status: 409,
+        headers: { 'content-type': 'application/json' }
+      })
+    )
+    await expect(
+      grantMantaCloudSessionDirectly(
+        { ...config, enrollmentSecret: 'open-sesame' },
+        'local-default'
+      )
+    ).rejects.toMatchObject({ statusCode: 409, errorCode: 'accounts_required' })
+  })
+
+  it('reads `code` as well as `error`, whichever surface answered', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ code: 'artifact_not_found' }), {
+        status: 404,
+        headers: { 'content-type': 'application/json' }
+      })
+    )
+    await expect(
+      grantMantaCloudSessionDirectly(
+        { ...config, enrollmentSecret: 'open-sesame' },
+        'local-default'
+      )
+    ).rejects.toMatchObject({ statusCode: 404, errorCode: 'artifact_not_found' })
+  })
+
+  it('still raises the status when the body is not JSON', async () => {
+    // A proxy's HTML error page is a normal failure shape and must not become
+    // a parse error in place of the status the caller needs.
+    fetchMock.mockResolvedValueOnce(
+      new Response('<html>502 Bad Gateway</html>', {
+        status: 502,
+        headers: { 'content-type': 'text/html' }
+      })
+    )
+    await expect(
+      grantMantaCloudSessionDirectly(
+        { ...config, enrollmentSecret: 'open-sesame' },
+        'local-default'
+      )
+    ).rejects.toMatchObject({ statusCode: 502, errorCode: undefined })
+  })
+})

--- a/src/main/manta-profiles/profile-cloud-client.ts
+++ b/src/main/manta-profiles/profile-cloud-client.ts
@@ -6,7 +6,7 @@ import type {
 import type { MantaCloudAuthConfig } from './profile-cloud-auth-config'
 import type { MantaCloudSession } from './profile-cloud-session-store'
 import type { MantaCloudSessionExchangeResponse } from './profile-cloud-session-exchange'
-import { cancelUnreadResponseBody } from '../lib/unread-response-body'
+import { readCloudErrorCode } from './profile-cloud-error-body'
 
 type ExchangeCodeArgs = {
   code: string
@@ -195,8 +195,16 @@ async function postJson<T>(url: string, body: unknown, options?: PostJsonOptions
     signal: AbortSignal.timeout(options?.timeoutMs ?? CLOUD_REQUEST_TIMEOUT_MS)
   })
   if (!response.ok) {
-    await cancelUnreadResponseBody(response)
-    throw new MantaCloudRequestError(response.status)
+    // Why the body is read on the failure path: the relay names what went wrong
+    // here, and callers map some of those names to a sentence a person can act
+    // on — 'accounts_required' becomes "sign in from Settings → Manta Account".
+    // Discarding it made every one of those mappings unreachable, so the person
+    // who most needed the instruction got `manta_cloud_request_failed_409`.
+    //
+    // Bounded and best-effort: a failure body is small, and an unparseable one
+    // must still raise the status rather than the parse error.
+    const code = await readCloudErrorCode(response)
+    throw new MantaCloudRequestError(response.status, code)
   }
   return (await response.json()) as T
 }

--- a/src/main/manta-profiles/profile-cloud-error-body.ts
+++ b/src/main/manta-profiles/profile-cloud-error-body.ts
@@ -1,0 +1,87 @@
+/**
+ * The relay's name for a failure, read off the response that carries it.
+ *
+ * Its own module because it is the one place that reads a body nobody asked
+ * for, under two constraints that pull against each other: the name has to
+ * come out, and the body must never be left unread — leaving one can take the
+ * process down from inside Node's bundled undici (see unread-response-body.ts).
+ */
+/** A body that will not arrive must not hold the sign-in call open. */
+const ERROR_BODY_READ_TIMEOUT_MS = 2_000
+/** An error name is a short string; anything larger is not one. */
+const ERROR_BODY_MAX_BYTES = 64 * 1024
+
+/**
+ * The relay's name for a failure, if it gave one.
+ *
+ * Accepts `error` as well as `code`: the auth endpoints answer with `error` and
+ * the artifact endpoints with `code`, and a caller matching on the name should
+ * not have to know which surface answered.
+ *
+ * Why the read is raced rather than simply awaited: a body can stall half-sent,
+ * and there is no timeout on reading one — the fetch signal has already been
+ * satisfied by the headers. Left unbounded, a stalled error body would hang the
+ * awaited IPC call behind it forever. Whichever way it ends, the body is read
+ * or cancelled, because leaving one unread can take the process down from
+ * inside bundled undici.
+ */
+export async function readCloudErrorCode(response: Response): Promise<string | undefined> {
+  const stream = response.body
+  if (!stream) {
+    return undefined
+  }
+  // Why a reader rather than response.json(): json() locks the stream, and a
+  // cancel on a locked stream throws instead of cancelling — so the body would
+  // be left unread after all, which is the failure this guards against. Owning
+  // the reader means the same handle that stalls is the one that cancels.
+  const reader = stream.getReader()
+  const chunks: Uint8Array[] = []
+  let size = 0
+  let abandoned = false
+  const deadline = setTimeout(() => {
+    abandoned = true
+    void reader.cancel().catch(() => {})
+  }, ERROR_BODY_READ_TIMEOUT_MS)
+  deadline.unref?.()
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) {
+        break
+      }
+      if (!value) {
+        continue
+      }
+      size += value.byteLength
+      if (size > ERROR_BODY_MAX_BYTES) {
+        abandoned = true
+        await reader.cancel()
+        break
+      }
+      chunks.push(value)
+    }
+  } catch {
+    // The read was cancelled under us, or the socket died mid-body.
+    abandoned = true
+  } finally {
+    clearTimeout(deadline)
+  }
+  if (abandoned) {
+    return undefined
+  }
+  try {
+    const parsed = JSON.parse(Buffer.concat(chunks).toString('utf8')) as {
+      code?: unknown
+      error?: unknown
+    } | null
+    for (const candidate of [parsed?.code, parsed?.error]) {
+      if (typeof candidate === 'string' && candidate) {
+        return candidate
+      }
+    }
+  } catch {
+    // A failure with no JSON body is ordinary — a proxy's HTML error page, say.
+    // The status is what the caller falls back to, and the body is fully read.
+  }
+  return undefined
+}


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​98 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​95 |

<!-- /manta-pr-loc -->

Found by hitting it: signing in to a per-user self-hosted relay answered
`manta_cloud_request_failed_409`, which names nothing a person can act on.

There was already a sentence for exactly that failure —
profile-cloud-service maps `accounts_required` to *"this relay gives each
person their own account. Sign in from Settings → Manta Account."* It could
never run. `postJson` cancelled the response body and threw with no code, so
`errorCode` was always `undefined` and every mapping keyed on it was dead.
The class comment has said since it was written that `errorCode` carries the
server's discriminator; this path never gave it one.

## Reading a body nobody asked for

Two constraints pull against each other here. The name is in the body, so it
has to be read. And an unread body can take the process down from inside
Node's bundled undici (#8695), so it must never be left that way.

`response.json()` cannot satisfy both: it locks the stream, and a cancel on a
locked stream throws instead of cancelling — the body ends up unread anyway.
An existing test caught this, which is how I know rather than assume. So the
read owns the reader, and whichever way it ends the body is read or cancelled
through the same handle.

Bounded both ways — 64 KiB and two seconds — because a body can stall
half-sent and there is no timeout on reading one; the fetch signal was
already satisfied by the headers. Unbounded, an error nobody could name would
hang the awaited sign-in behind it.

Both `error` and `code` are accepted: the auth endpoints answer with one and
the artifact endpoints with the other, and a caller matching on the name
should not have to know which surface replied.

Three tests: the code comes out of a 409, `code` works as well as `error`,
and a proxy's HTML error page still raises its status instead of a parse
error. The existing cancel-the-unread-body test passes unchanged.