### PR TITLE
fix(relay): serve the write API on the artifact origin, as the desktop sends it

### DIFF
--- a/relay-server/README.md
+++ b/relay-server/README.md
@@ -338,9 +338,15 @@ viewer's browser. **The separate origin is the isolation.** Nothing else in this
 section substitutes for it: not the CSP, not the sandbox headers, not the
 markdown escaping.
 
-The write API stays on the relay's name. Only `GET /a/{slug}` is served on the
-artifact origin, so an access token never has a reason to be sent to the origin
-that serves the pages.
+Both artifact surfaces are served on the artifact origin: `GET /a/{slug}` and
+`/v1/artifacts`. The desktop builds every artifact URL from the host it is
+configured with, so the write API arrives on that name rather than the relay's.
+
+A published page is same-origin with that write API and can call it, but it has
+no credential to call it *with* — the bearer lives in the desktop app, nothing
+is stored in the browser, and an unauthenticated call gets a 401. What the
+separate origin prevents is the page reaching the relay's auth and cell
+endpoints as the signed-in desktop, and that is unaffected.
 
 ### What it does with what you publish
 

--- a/relay-server/deploy/Caddyfile
+++ b/relay-server/deploy/Caddyfile
@@ -51,11 +51,23 @@
 #{$ARTIFACTS_DOMAIN} {
 #	import hardened
 #
-#	# Only the public page. The write API stays on the relay's own name, so a
-#	# token never has a reason to be sent to the origin that serves the pages.
-#	@artifact path /a/*
-#	reverse_proxy @artifact relay:8787
-#	respond 404
+#	# Both artifact surfaces, and nothing else on this name. The desktop sends
+#	# the write API here too: the artifact host it is configured with is the
+#	# origin it builds every artifact URL from, so /v1/artifacts arrives on this
+#	# name rather than the relay's.
+#	#
+#	# handle blocks rather than a matcher beside a bare respond: Caddy reorders
+#	# directives by its own precedence, where the unmatched respond wins and
+#	# every request 404s — including the ones meant for the relay.
+#	@artifacts path /a/* /v1/artifacts /v1/artifacts/*
+#	handle @artifacts {
+#		reverse_proxy relay:8787 {
+#			flush_interval -1
+#		}
+#	}
+#	handle {
+#		respond 404
+#	}
 #}
 
 {$RELAY_DOMAIN} {

--- a/relay-server/src/artifacts/store.test.ts
+++ b/relay-server/src/artifacts/store.test.ts
@@ -1,0 +1,105 @@
+import type * as Crypto from 'node:crypto'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Slug allocation, with the random source under the test's control.
+ *
+ * Forced rather than waited for: at ninety-six bits a real collision will not
+ * happen in a test run, and the consequence — one account's page overwritten by
+ * another's, served under a link already handed out — is worth a proof rather
+ * than an argument about odds.
+ */
+const nextBytes: Buffer[] = []
+
+vi.mock('node:crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof Crypto>()
+  return {
+    ...actual,
+    randomBytes: (size: number) => nextBytes.shift() ?? actual.randomBytes(size)
+  }
+})
+
+const { ArtifactStore } = await import('./store.js')
+type ArtifactWrite = Parameters<InstanceType<typeof ArtifactStore>['create']>[0]
+
+const QUOTA = { maxPerAccount: 100, maxTotalBytesPerAccount: 1024 * 1024 }
+
+function store(): InstanceType<typeof ArtifactStore> {
+  // No data directory: bodies stay in memory, keyed by slug, which is what
+  // makes the slug the only thing separating one page's storage from another's.
+  return new ArtifactStore(null, () => {}, QUOTA, 'test-secret')
+}
+
+function write(overrides: Partial<ArtifactWrite> = {}): ArtifactWrite {
+  return {
+    accountId: 'acct-a',
+    title: null,
+    originalFileName: 'a.html',
+    sourceContentType: 'text/html',
+    byteSize: 10,
+    html: '<h1>a</h1>',
+    ttlMs: 60_000,
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  nextBytes.length = 0
+})
+
+afterEach(() => {
+  nextBytes.length = 0
+})
+
+describe('slug allocation', () => {
+  it('refuses a slug already taken and draws another', () => {
+    const collision = Buffer.alloc(12, 7)
+    const free = Buffer.alloc(12, 9)
+    nextBytes.push(collision, collision, free)
+
+    const subject = store()
+    const first = subject.create(write(), Date.now(), null)
+    const second = subject.create(
+      write({ accountId: 'acct-b', html: '<h1>b</h1>' }),
+      Date.now(),
+      null
+    )
+
+    expect(second.record.slug).not.toBe(first.record.slug)
+    // The proof that matters: neither page was overwritten by the other.
+    expect(subject.readBody(first.record.slug)).toBe('<h1>a</h1>')
+    expect(subject.readBody(second.record.slug)).toBe('<h1>b</h1>')
+  })
+
+  it('refuses a slug an expired record still holds', () => {
+    // An expired record keeps its stored page until the sweep runs, so reusing
+    // its slug would clobber a page whose link is still in someone's hands.
+    const expired = Buffer.alloc(12, 1)
+    nextBytes.push(expired, expired, Buffer.alloc(12, 2))
+
+    const subject = store()
+    const stale = subject.create(write({ ttlMs: 1 }), Date.now() - 10_000, null)
+    expect(subject.find(stale.record.slug, Date.now())).toBeNull()
+
+    const next = subject.create(write({ html: '<h1>next</h1>' }), Date.now(), null)
+    expect(next.record.slug).not.toBe(stale.record.slug)
+    expect(subject.readBody(stale.record.slug)).toBe('<h1>a</h1>')
+  })
+
+  it('gives up rather than serve one account page from another account link', () => {
+    // A source that only ever returns one value is broken, not unlucky, and
+    // carrying on would mean exactly the overwrite this guard exists to stop.
+    const only = Buffer.alloc(12, 5)
+    const subject = store()
+    nextBytes.push(only)
+    const first = subject.create(write(), Date.now(), null)
+
+    for (let i = 0; i < 16; i += 1) {
+      nextBytes.push(only)
+    }
+    expect(() => subject.create(write({ accountId: 'acct-b' }), Date.now(), null)).toThrow(
+      'artifact_slug_unavailable'
+    )
+    expect(subject.readBody(first.record.slug)).toBe('<h1>a</h1>')
+  })
+})

--- a/relay-server/src/artifacts/store.ts
+++ b/relay-server/src/artifacts/store.ts
@@ -170,12 +170,37 @@ export class ArtifactStore {
     return null
   }
 
+  /**
+   * A slug nothing else holds.
+   *
+   * Ninety-six bits makes a collision vanishingly unlikely, but not harmless:
+   * the body is a file named by slug, so a second record with the same one
+   * would overwrite the first account's page with this account's content and
+   * serve it under a link they had already given people. Cheap to make
+   * structurally impossible rather than argue about the odds.
+   *
+   * Checked against every record, not the live ones: an expired record still
+   * has its file on disk until the sweep runs, and that file is what a
+   * collision would clobber.
+   */
+  private freeSlug(): string {
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      const slug = randomBytes(12).toString('base64url')
+      if (!this.records.some((record) => record.slug === slug)) {
+        return slug
+      }
+    }
+    // Eight collisions in a row is not chance; it is a broken random source,
+    // and continuing would mean serving one account's page from another's link.
+    throw new Error('artifact_slug_unavailable')
+  }
+
   create(
     write: ArtifactWrite,
     now: number,
     idempotencyKey: string | null
   ): { record: ArtifactRecord; editToken: string } {
-    const slug = randomBytes(12).toString('base64url')
+    const slug = this.freeSlug()
     const editToken = this.editTokenFor(slug)
     const record: ArtifactRecord = {
       slug,

--- a/src/main/artifacts/artifact-cloud-config.test.ts
+++ b/src/main/artifacts/artifact-cloud-config.test.ts
@@ -109,14 +109,22 @@ describe('resolveArtifactCloudApiUrl with a configured artifact host', () => {
     // started from the Dock inherits none, which is why the field outranks it.
     setMantaCloudEndpointOverrideSource(() => ({ artifactsBaseUrl: 'https://share.example.com' }))
     expect(
-      resolveArtifactCloudApiUrl(undefined, { MANTA_ARTIFACTS_API_URL: 'https://env.example' }, true)
+      resolveArtifactCloudApiUrl(
+        undefined,
+        { MANTA_ARTIFACTS_API_URL: 'https://env.example' },
+        true
+      )
     ).toBe('https://share.example.com')
   })
 
   it('falls back to the variable, then the built-in host, as the field empties', () => {
     setMantaCloudEndpointOverrideSource(() => ({}))
     expect(
-      resolveArtifactCloudApiUrl(undefined, { MANTA_ARTIFACTS_API_URL: 'https://env.example' }, true)
+      resolveArtifactCloudApiUrl(
+        undefined,
+        { MANTA_ARTIFACTS_API_URL: 'https://env.example' },
+        true
+      )
     ).toBe('https://env.example')
     expect(resolveArtifactCloudApiUrl(undefined, {}, true)).toBe('https://share.manta.sh.cn')
   })
@@ -139,5 +147,21 @@ describe('resolveArtifactCloudApiUrl with a configured artifact host', () => {
       throw new Error('settings unreadable')
     })
     expect(resolveArtifactCloudApiUrl(undefined, {}, true)).toBe('https://share.manta.sh.cn')
+  })
+})
+
+describe('where the artifact API is actually sent', () => {
+  afterEach(() => {
+    resetMantaCloudEndpointOverrideSourceForTests()
+  })
+
+  it('addresses the write API to the artifact host, not the relay', () => {
+    // Deployment-shaped, and the reason this is a test rather than a comment:
+    // a Caddy site that proxied only /a/* on the artifact origin 404'd every
+    // publish, because artifactRequest builds `${apiUrl}/v1/artifacts` from
+    // exactly this value. Anyone routing that origin has to serve both.
+    setMantaCloudEndpointOverrideSource(() => ({ artifactsBaseUrl: 'https://share.example.com' }))
+    const apiUrl = resolveArtifactCloudApiUrl(undefined, {}, true)
+    expect(`${apiUrl}/v1/artifacts`).toBe('https://share.example.com/v1/artifacts')
   })
 })


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​131 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​129 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 |

<!-- /manta-pr-loc -->

Found by deploying it. Every publish answered "Could not share artifact", and
the relay logs showed nothing at all — the requests were being 404'd by the
reverse proxy before they arrived.

The deploy guidance I wrote said the write API stays on the relay's name and
only `GET /a/{slug}` belongs on the artifact origin. That was an assumption
written down rather than checked. `artifactRequest` builds
`${apiUrl}/v1/artifacts` from the configured artifact host, so **every** call
goes to that origin, and a site following the old comment drops all of them.

The block now routes both surfaces and nothing else.

## Two things worth keeping

**`handle` blocks, not a matcher beside a bare `respond 404`.** Caddy reorders
directives by its own precedence; the unmatched `respond` wins and every
request 404s, including the ones meant for the relay. That is what the first
fix attempt did.

**The obvious check cannot see either failure.** `GET /a/{slug}` returns 404
whether the proxy refused it or the relay has no such slug. Only a request that
should be *401* — an unauthenticated `/v1/artifacts` — tells the two apart. The
verification in this PR uses that one.

## The origin rule is unaffected

A published page is now same-origin with the write API and can call it. It has
no credential to call it with: the bearer lives in the desktop app, nothing is
stored in the browser, and an unauthenticated call is a 401. What the separate
origin prevents — that page reaching the relay's auth and cell endpoints as the
signed-in desktop — is unchanged.

The desktop test pins the URL actually formed, since that is the fact a
deployment has to match.