### PR TITLE
feat(relay): shorter artifact links, and markdown that renders real notes

### DIFF
--- a/relay-server/README.md
+++ b/relay-server/README.md
@@ -338,8 +338,11 @@ viewer's browser. **The separate origin is the isolation.** Nothing else in this
 section substitutes for it: not the CSP, not the sandbox headers, not the
 markdown escaping.
 
-Both artifact surfaces are served on the artifact origin: `GET /a/{slug}` and
-`/v1/artifacts`. The desktop builds every artifact URL from the host it is
+Both artifact surfaces are served on the artifact origin: the published link
+at `GET /{slug}` and the write API at `/v1/artifacts`. A slug is sixteen
+base64url characters, which is what keeps the root namespace unambiguous beside
+the API without reserving anything. `/a/{slug}` still resolves — it is the form
+the first release handed out, and a shared link is not ours to break. The desktop builds every artifact URL from the host it is
 configured with, so the write API arrives on that name rather than the relay's.
 
 A published page is same-origin with that write API and can call it, but it has
@@ -352,11 +355,13 @@ endpoints as the signed-in desktop, and that is unaffected.
 
 | Source | Stored as | Why |
 | --- | --- | --- |
-| `text/markdown` | HTML this relay rendered | Rendered by `src/artifacts/markdown.ts`, which escapes every byte first and then builds a small, fixed set of tags. Raw HTML in the source shows as text. There is no sanitizer to bypass because nothing is passed through. |
+| `text/markdown` | HTML this relay rendered | Rendered by `src/artifacts/markdown.ts`, which escapes every byte first and then builds a fixed set of tags. There is no sanitizer to bypass because nothing is passed through — and so raw HTML in the source shows as text. Front matter is dropped; headings, lists, task lists, tables, code, quotes, images, links, emphasis and strikethrough render. |
 | `text/html` | exactly what was sent | Rewriting someone's document is not this server's job, and a filter is not what contains it — the origin is. |
 
 So an HTML artifact **is** arbitrary script on the artifact origin, by design.
 That is the feature working, and it is the reason for every paragraph above.
+
+Only Markdown and HTML can be published; those are the two the desktop sends.
 
 Published pages carry `X-Frame-Options: DENY`, `nosniff`, `no-referrer`,
 `no-store`, and a CSP of `frame-ancestors 'none'; base-uri 'none'; form-action

--- a/relay-server/deploy/Caddyfile
+++ b/relay-server/deploy/Caddyfile
@@ -51,20 +51,29 @@
 #{$ARTIFACTS_DOMAIN} {
 #	import hardened
 #
-#	# Both artifact surfaces, and nothing else on this name. The desktop sends
-#	# the write API here too: the artifact host it is configured with is the
-#	# origin it builds every artifact URL from, so /v1/artifacts arrives on this
-#	# name rather than the relay's.
+#	# Only the artifact surfaces reach the relay on this name. Proxying
+#	# everything puts /v1/desktop/auth/* on the origin that serves pages written
+#	# by whoever published them, which is the exact thing a separate origin
+#	# exists to prevent. The relay refuses those on this name too, so a proxy
+#	# written more loosely than this one is a mistake rather than a breach.
 #	#
-#	# handle blocks rather than a matcher beside a bare respond: Caddy reorders
-#	# directives by its own precedence, where the unmatched respond wins and
-#	# every request 404s — including the ones meant for the relay.
-#	@artifacts path /a/* /v1/artifacts /v1/artifacts/*
-#	handle @artifacts {
+#	# A slug is sixteen base64url characters; path_regexp matches that shape and
+#	# nothing else, so the root namespace stays unambiguous. /a/ is the older
+#	# form of the same link.
+#	@published path_regexp ^/(a/)?[A-Za-z0-9_-]{16}$
+#	handle @published {
 #		reverse_proxy relay:8787 {
 #			flush_interval -1
 #		}
 #	}
+#
+#	@writes path /v1/artifacts /v1/artifacts/*
+#	handle @writes {
+#		reverse_proxy relay:8787 {
+#			flush_interval -1
+#		}
+#	}
+#
 #	handle {
 #		respond 404
 #	}

--- a/relay-server/src/artifacts.test.ts
+++ b/relay-server/src/artifacts.test.ts
@@ -8,6 +8,7 @@
  * credential this module invented.
  */
 import { mkdtempSync, rmSync } from 'node:fs'
+import { request as httpRequest } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -81,6 +82,33 @@ function api(
   })
 }
 
+/**
+ * A request with a Host header of our choosing.
+ *
+ * Not fetch: undici treats Host as a forbidden header and drops it silently,
+ * so a test written with fetch would pass against a relay that ignored the
+ * origin entirely — it would never have sent the header being tested.
+ */
+function requestWithHost(
+  origin: string,
+  path: string,
+  host: string,
+  method = 'GET'
+): Promise<number> {
+  const target = new URL(origin)
+  return new Promise((resolve, reject) => {
+    const request = httpRequest(
+      { host: target.hostname, port: target.port, path, method, headers: { host } },
+      (response) => {
+        response.resume()
+        response.on('end', () => resolve(response.statusCode ?? 0))
+      }
+    )
+    request.on('error', reject)
+    request.end()
+  })
+}
+
 const HTML_BODY = {
   content: '<h1>Report</h1>',
   contentType: 'text/html',
@@ -99,7 +127,7 @@ describe('artifact hosting is off unless asked for', () => {
     current = await startTestRelay(() => PER_USER)
     const token = await signIn(current.origin)
     expect((await api(current.origin, '', token)).status).toBe(404)
-    expect((await fetch(`${current.origin}/a/anything`)).status).toBe(404)
+    expect((await fetch(`${current.origin}/AAAAAAAAAAAAAAAA`)).status).toBe(404)
     expect(current.relay.artifacts).toBeNull()
   })
 })
@@ -153,7 +181,7 @@ describe('publishing', () => {
     const created = await api(current.origin, '', token, { method: 'POST', body: HTML_BODY })
     expect(created.status).toBe(201)
     const body = (await created.json()) as Created
-    expect(body.shareUrl).toBe(`${SHARE_ORIGIN}/a/${body.artifact.slug}`)
+    expect(body.shareUrl).toBe(`${SHARE_ORIGIN}/${body.artifact.slug}`)
     expect(body.editToken).toBeTruthy()
     expect(body.artifact.sourceContentType).toBe('text/html')
     expect(Date.parse(body.artifact.expiresAt)).toBeGreaterThan(Date.now())
@@ -169,7 +197,7 @@ describe('publishing', () => {
       body: { ...HTML_BODY, content: '<h1>Revised</h1>' }
     })
     expect(updated.status).toBe(200)
-    expect(await (await fetch(`${current.origin}/a/${body.artifact.slug}`)).text()).toContain(
+    expect(await (await fetch(`${current.origin}/${body.artifact.slug}`)).text()).toContain(
       'Revised'
     )
 
@@ -178,7 +206,7 @@ describe('publishing', () => {
       editToken: body.editToken
     })
     expect(deleted.status).toBe(204)
-    expect((await fetch(`${current.origin}/a/${body.artifact.slug}`)).status).toBe(404)
+    expect((await fetch(`${current.origin}/${body.artifact.slug}`)).status).toBe(404)
   })
 
   it('replays a create whose response was lost, with the same edit token', async () => {
@@ -223,7 +251,7 @@ describe('publishing', () => {
       })
     ).json()) as Created
 
-    const page = await fetch(`${current.origin}/a/${created.artifact.slug}`)
+    const page = await fetch(`${current.origin}/${created.artifact.slug}`)
     const html = await page.text()
     expect(html).toContain('<h1>Title</h1>')
     expect(html).not.toContain('<script>')
@@ -299,9 +327,9 @@ describe('limits', () => {
   it('refuses one more artifact than the account may hold', async () => {
     current = await startWithArtifacts({ maxPerAccount: 1 })
     const token = await signIn(current.origin)
-    expect(
-      (await api(current.origin, '', token, { method: 'POST', body: HTML_BODY })).status
-    ).toBe(201)
+    expect((await api(current.origin, '', token, { method: 'POST', body: HTML_BODY })).status).toBe(
+      201
+    )
     const second = await api(current.origin, '', token, { method: 'POST', body: HTML_BODY })
     expect(second.status).toBe(413)
     expect((await second.json()) as { code: string }).toMatchObject({ code: 'too_many' })
@@ -334,7 +362,7 @@ describe('the published page', () => {
     const created = (await (
       await api(current.origin, '', token, { method: 'POST', body: HTML_BODY })
     ).json()) as Created
-    const page = await fetch(`${current.origin}/a/${created.artifact.slug}`)
+    const page = await fetch(`${current.origin}/${created.artifact.slug}`)
     expect(page.headers.get('x-frame-options')).toBe('DENY')
     expect(page.headers.get('x-content-type-options')).toBe('nosniff')
     expect(page.headers.get('referrer-policy')).toBe('no-referrer')
@@ -356,7 +384,7 @@ describe('the published page', () => {
         body: { ...HTML_BODY, content: '<h1>Kept</h1><script>window.x=1</script>' }
       })
     ).json()) as Created
-    const html = await (await fetch(`${current.origin}/a/${created.artifact.slug}`)).text()
+    const html = await (await fetch(`${current.origin}/${created.artifact.slug}`)).text()
     expect(html).toBe('<h1>Kept</h1><script>window.x=1</script>')
   })
 })
@@ -372,7 +400,7 @@ describe('durability', () => {
 
     const { restartTestRelay } = await import('./testing/harness.js')
     current = await restartTestRelay(current)
-    const page = await fetch(`${current.origin}/a/${created.artifact.slug}`)
+    const page = await fetch(`${current.origin}/${created.artifact.slug}`)
     expect(page.status).toBe(200)
     expect(await page.text()).toContain('Report')
   })
@@ -384,9 +412,67 @@ describe('durability', () => {
       await api(current.origin, '', token, { method: 'POST', body: HTML_BODY })
     ).json()) as Created
     await new Promise((resolve) => setTimeout(resolve, 20))
-    expect((await fetch(`${current.origin}/a/${created.artifact.slug}`)).status).toBe(404)
+    expect((await fetch(`${current.origin}/${created.artifact.slug}`)).status).toBe(404)
     const page = (await (await api(current.origin, '', token)).json()) as { artifacts: unknown[] }
     expect(page.artifacts).toHaveLength(0)
     expect(current.relay.artifacts?.size).toBe(0)
+  })
+})
+
+describe('published links', () => {
+  it('serves at the root and keeps the old /a/ form working', async () => {
+    // The first release handed out /a/<slug>; a link someone already shared is
+    // not ours to break, so both resolve to the same page.
+    current = await startWithArtifacts()
+    const token = await signIn(current.origin)
+    const created = (await (
+      await api(current.origin, '', token, { method: 'POST', body: HTML_BODY })
+    ).json()) as Created
+
+    expect(created.shareUrl).toBe(`${SHARE_ORIGIN}/${created.artifact.slug}`)
+    for (const path of [`/${created.artifact.slug}`, `/a/${created.artifact.slug}`]) {
+      const page = await fetch(`${current.origin}${path}`)
+      expect(page.status).toBe(200)
+      expect(await page.text()).toContain('Report')
+    }
+  })
+
+  it('does not mistake another path for a slug', async () => {
+    // A slug is exactly sixteen base64url characters, which is what keeps the
+    // root namespace unambiguous next to the write API.
+    current = await startWithArtifacts()
+    for (const path of ['/v1/artifacts', '/short', '/.well-known/acme-challenge/x']) {
+      const response = await fetch(`${current.origin}${path}`)
+      expect(response.status).not.toBe(200)
+    }
+  })
+})
+
+describe('the artifact origin serves artifacts and nothing else', () => {
+  it('refuses auth, cell, and health routes arriving on the artifact host', async () => {
+    // Defence in depth against the proxy, not instead of it. A published page
+    // is same-origin with whatever answers on this name, so auth reachable
+    // here would undo the reason the origin is separate — and the proxy that
+    // is supposed to prevent it is a config file someone can write too loosely.
+    // I did exactly that, which is why this is a test rather than a comment.
+    current = await startWithArtifacts()
+    const host = new URL(SHARE_ORIGIN).host
+    for (const path of ['/v1/desktop/auth/methods', '/v1/assign', '/v1/resolve', '/health']) {
+      expect(await requestWithHost(current.origin, path, host)).toBe(404)
+    }
+  })
+
+  it('still answers those routes on the relay host', async () => {
+    current = await startWithArtifacts()
+    const host = new URL(current.origin).host
+    expect(await requestWithHost(current.origin, '/v1/desktop/auth/methods', host)).toBe(200)
+    expect(await requestWithHost(current.origin, '/health', host)).toBe(200)
+  })
+
+  it('serves the artifact surfaces on the artifact host', async () => {
+    current = await startWithArtifacts()
+    const host = new URL(SHARE_ORIGIN).host
+    expect(await requestWithHost(current.origin, '/v1/artifacts', host, 'POST')).toBe(401)
+    expect(await requestWithHost(current.origin, '/AAAAAAAAAAAAAAAA', host)).toBe(404)
   })
 })

--- a/relay-server/src/artifacts/markdown-inline.ts
+++ b/relay-server/src/artifacts/markdown-inline.ts
@@ -1,0 +1,81 @@
+/**
+ * Inline markdown, over text that has already been HTML-escaped.
+ *
+ * Escaping happens before any rule here runs, so the only tags in the output
+ * are ones this file writes. That is the whole safety argument for rendering
+ * markdown in a process that holds credentials: there is no sanitizer to
+ * bypass, because nothing is ever passed through.
+ */
+
+/** Schemes a link may use. Anything else stays as the text the author typed. */
+const SAFE_LINK = /^(https?:\/\/|mailto:)/i
+/** Images are fetched by the viewer's browser, so no data: or other schemes. */
+const SAFE_IMAGE = /^https?:\/\//i
+
+/**
+ * Marks where a code span was lifted out.
+ *
+ * NUL, and stripped from the source before anything runs, because a printable
+ * placeholder would eventually appear in someone's prose and be substituted
+ * back out of it.
+ */
+export const SENTINEL = String.fromCharCode(0)
+const SENTINEL_PATTERN = new RegExp(`${SENTINEL}(\\d+)${SENTINEL}`, 'g')
+
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/** Undoes escaping for a URL that is about to be checked for its scheme. */
+function unescapeUrl(value: string): string {
+  return value
+    .replace(/&amp;/g, '&')
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+}
+
+/**
+ * Inline spans.
+ *
+ * Order matters twice: code spans come out first so a backtick span containing
+ * `**` or a bracket is not re-read as markup, and images run before links
+ * because `![alt](src)` contains a link's exact shape.
+ */
+export function inline(escaped: string): string {
+  const codes: string[] = []
+  let text = escaped.replace(/`([^`]+)`/g, (_match, code: string) => {
+    codes.push(`<code>${code}</code>`)
+    return `${SENTINEL}${codes.length - 1}${SENTINEL}`
+  })
+
+  text = text.replace(/!\[([^\]\n]*)\]\(([^)\s]+)\)/g, (match, alt: string, src: string) => {
+    if (!SAFE_IMAGE.test(unescapeUrl(src))) {
+      return match
+    }
+    // loading=lazy because a shared note can carry a lot of them, and referrer
+    // policy because the page a link was shared from is nobody else's business.
+    return `<img src="${src}" alt="${alt}" loading="lazy" referrerpolicy="no-referrer">`
+  })
+
+  text = text.replace(/\[([^\]\n]*)\]\(([^)\s]+)\)/g, (match, label: string, href: string) => {
+    if (!SAFE_LINK.test(unescapeUrl(href))) {
+      return match
+    }
+    // rel on every link: these pages are written by whoever published them, and
+    // an opener reference would hand one a handle on the page that linked it.
+    return `<a href="${href}" rel="noopener noreferrer nofollow" target="_blank">${label}</a>`
+  })
+
+  text = text
+    .replace(/~~([^~\n]+)~~/g, '<del>$1</del>')
+    .replace(/\*\*([^*\n]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/(^|[^*\w])\*([^*\n]+)\*(?![*\w])/g, '$1<em>$2</em>')
+    .replace(/(^|[^_\w])_([^_\n]+)_(?![_\w])/g, '$1<em>$2</em>')
+
+  return text.replace(SENTINEL_PATTERN, (_match, index: string) => codes[Number(index)] ?? '')
+}

--- a/relay-server/src/artifacts/markdown.test.ts
+++ b/relay-server/src/artifacts/markdown.test.ts
@@ -110,3 +110,68 @@ describe('renderMarkdown structure', () => {
     expect(html).not.toContain(String.fromCharCode(0))
   })
 })
+
+describe('what real notes actually contain', () => {
+  it('drops YAML front matter instead of rendering it as content', () => {
+    // Note tools put title/tags/dates up there. Rendered, it came out as a rule
+    // plus a paragraph of YAML — a shared note looking broken before its first
+    // heading, which is what sent someone looking for a bug.
+    const html = renderMarkdown('---\ntitle: Note\ntags: [a, b]\n---\n\n# Body')
+    expect(html).toBe('<h1>Body</h1>')
+  })
+
+  it('treats unterminated dashes as a rule, not as front matter', () => {
+    const html = renderMarkdown('---\n\ntext')
+    expect(html).toContain('<hr>')
+    expect(html).toContain('<p>text</p>')
+  })
+
+  it('renders a pipe table with its alignments', () => {
+    const html = renderMarkdown(
+      ['| a | b | c |', '| :-- | :-: | --: |', '| 1 | 2 | 3 |', '| 4 | 5 | 6 |'].join('\n')
+    )
+    expect(html).toContain('<table>')
+    expect(html).toContain('<th style="text-align:left">a</th>')
+    expect(html).toContain('<th style="text-align:center">b</th>')
+    expect(html).toContain('<th style="text-align:right">c</th>')
+    expect(html.match(/<tr>/g)).toHaveLength(3)
+  })
+
+  it('leaves pipes alone without a separator row', () => {
+    const html = renderMarkdown('a | b | c')
+    expect(html).not.toContain('<table>')
+    expect(html).toContain('<p>a | b | c</p>')
+  })
+
+  it('renders task list items as disabled checkboxes', () => {
+    const html = renderMarkdown(['- [ ] todo', '- [x] done'].join('\n'))
+    expect(html).toContain('<input type="checkbox" disabled> todo')
+    expect(html).toContain('<input type="checkbox" disabled checked> done')
+  })
+
+  it('renders an image rather than a link with a stray bang', () => {
+    const html = renderMarkdown('![alt](https://a.example/x.png)')
+    expect(html).toContain('<img src="https://a.example/x.png" alt="alt"')
+    expect(html).not.toContain('!<a')
+  })
+
+  it('refuses an image source that is not http', () => {
+    // The viewer's browser fetches these, so a data: or javascript: source is
+    // not ours to hand it.
+    for (const src of ['javascript:alert(1)', 'data:image/svg+xml,<svg onload=alert(1)>']) {
+      const html = renderMarkdown(`![x](${src})`)
+      expect(html).not.toContain('<img')
+    }
+  })
+
+  it('renders strikethrough', () => {
+    expect(renderMarkdown('~~gone~~')).toContain('<del>gone</del>')
+  })
+
+  it('still escapes everything inside a table cell', () => {
+    // The invariant has to survive every new construct, not just the old ones.
+    const html = renderMarkdown(['| a |', '| --- |', '| <script>x</script> |'].join('\n'))
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;script&gt;')
+  })
+})

--- a/relay-server/src/artifacts/markdown.ts
+++ b/relay-server/src/artifacts/markdown.ts
@@ -7,73 +7,19 @@
  * thing in it, and the sanitizer would be load-bearing — one bypass and a
  * shared note becomes script on the artifact origin.
  *
- * The order here removes that class of bug instead of filtering it: every byte
- * is escaped first, so the only tags in the output are ones this file wrote.
- * Raw HTML in the source is shown as text, which is a documented limitation
- * rather than a hole. Authors who need real HTML publish an HTML artifact,
- * which is served verbatim and is why the artifact origin must be its own.
+ * The order removes that class of bug instead of filtering it: every byte is
+ * escaped first, so the only tags in the output are ones this code wrote. Raw
+ * HTML in a markdown source is therefore shown as text. That is a real
+ * limitation, and the way around it is to publish an HTML artifact, which is
+ * served verbatim — and is why the artifact origin has to be its own.
  *
- * The supported subset is deliberately small: headings, paragraphs, fenced and
- * inline code, ordered and unordered lists, block quotes, horizontal rules,
- * emphasis, and links to http, https, and mailto.
+ * Covered: front matter (removed), headings, paragraphs, fenced and inline
+ * code, ordered and unordered lists, task lists, tables, block quotes,
+ * horizontal rules, emphasis, strikethrough, images, and links.
  */
+import { escapeHtml, inline, SENTINEL } from './markdown-inline.js'
 
-const SAFE_LINK = /^(https?:\/\/|mailto:)/i
-
-/**
- * Marks where a code span was lifted out.
- *
- * NUL, and stripped from the source before anything runs, because a printable
- * placeholder cannot work: whatever shape it took would eventually appear in
- * someone's prose and be substituted back out of it.
- */
-const SENTINEL = String.fromCharCode(0)
-const SENTINEL_PATTERN = new RegExp(`${SENTINEL}(\\d+)${SENTINEL}`, 'g')
-
-export function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-}
-
-/**
- * Inline spans, over already-escaped text.
- *
- * Code spans are taken first and held aside, so a backtick span containing `**`
- * or a bracket is not then re-read as emphasis or a link.
- */
-function inline(escaped: string): string {
-  const codes: string[] = []
-  let text = escaped.replace(/`([^`]+)`/g, (_match, code: string) => {
-    codes.push(`<code>${code}</code>`)
-    return `${SENTINEL}${codes.length - 1}${SENTINEL}`
-  })
-
-  text = text.replace(/\[([^\]\n]*)\]\(([^)\s]+)\)/g, (match, label: string, href: string) => {
-    // The href arrives escaped, so the entities have to come back out for the
-    // scheme check and stay escaped in the attribute, where that form is right.
-    const raw = href
-      .replace(/&amp;/g, '&')
-      .replace(/&#39;/g, "'")
-      .replace(/&quot;/g, '"')
-    if (!SAFE_LINK.test(raw)) {
-      return match
-    }
-    // rel on every link: these pages are written by whoever published them, and
-    // an opener reference would hand one a handle on the page that linked it.
-    return `<a href="${href}" rel="noopener noreferrer nofollow" target="_blank">${label}</a>`
-  })
-
-  text = text
-    .replace(/\*\*([^*\n]+)\*\*/g, '<strong>$1</strong>')
-    .replace(/(^|[^*\w])\*([^*\n]+)\*(?![*\w])/g, '$1<em>$2</em>')
-    .replace(/(^|[^_\w])_([^_\n]+)_(?![_\w])/g, '$1<em>$2</em>')
-
-  return text.replace(SENTINEL_PATTERN, (_match, index: string) => codes[Number(index)] ?? '')
-}
+export { escapeHtml } from './markdown-inline.js'
 
 type ListState = { tag: 'ul' | 'ol'; open: boolean }
 
@@ -95,10 +41,99 @@ function openList(out: string[], list: ListState, tag: 'ul' | 'ol'): void {
   }
 }
 
+/**
+ * Drops a leading YAML front matter block.
+ *
+ * Note-taking tools put `title:`, `tags:` and dates up there, and it is
+ * metadata about the document rather than part of it. Rendered instead of
+ * removed, it came out as a horizontal rule followed by a paragraph of YAML —
+ * which is how a shared note looks broken before its first heading.
+ */
+function stripFrontMatter(lines: string[]): string[] {
+  if (lines[0]?.trim() !== '---') {
+    return lines
+  }
+  const end = lines.findIndex((line, index) => index > 0 && line.trim() === '---')
+  // No closing fence means those dashes were a horizontal rule, not metadata.
+  return end === -1 ? lines : lines.slice(end + 1)
+}
+
+/** A `| --- | :--: |` row, which is what makes the line above it a header. */
+function tableAlignments(line: string): string[] | null {
+  const trimmed = line.trim().replace(/^\|/, '').replace(/\|$/, '')
+  if (!trimmed.includes('-')) {
+    return null
+  }
+  const alignments: string[] = []
+  for (const cell of trimmed.split('|')) {
+    const spec = cell.trim()
+    if (!/^:?-+:?$/.test(spec)) {
+      return null
+    }
+    const left = spec.startsWith(':')
+    const right = spec.endsWith(':')
+    alignments.push(left && right ? 'center' : right ? 'right' : left ? 'left' : '')
+  }
+  return alignments.length > 0 ? alignments : null
+}
+
+function splitRow(line: string): string[] {
+  return line
+    .trim()
+    .replace(/^\|/, '')
+    .replace(/\|$/, '')
+    .split('|')
+    .map((cell) => cell.trim())
+}
+
+function renderRow(cells: string[], alignments: string[], tag: 'th' | 'td'): string {
+  const rendered = cells.map((cell, index) => {
+    const align = alignments[index]
+    const style = align ? ` style="text-align:${align}"` : ''
+    return `<${tag}${style}>${inline(cell)}</${tag}>`
+  })
+  return `<tr>${rendered.join('')}</tr>`
+}
+
+/** Emits a whole table and returns the index of its last consumed line. */
+function renderTable(
+  lines: string[],
+  headerIndex: number,
+  alignments: string[],
+  out: string[]
+): number {
+  out.push('<table>')
+  out.push(`<thead>${renderRow(splitRow(lines[headerIndex] ?? ''), alignments, 'th')}</thead>`)
+  out.push('<tbody>')
+  let index = headerIndex + 1
+  while (index + 1 < lines.length && (lines[index + 1] ?? '').includes('|')) {
+    index += 1
+    out.push(renderRow(splitRow(lines[index] ?? ''), alignments, 'td'))
+  }
+  out.push('</tbody>')
+  out.push('</table>')
+  return index
+}
+
+/** Renders one list item, which may be a task. */
+function renderListItem(body: string, out: string[]): void {
+  const task = /^\[([ xX])\]\s+(.*)$/.exec(body)
+  if (!task) {
+    out.push(`<li>${inline(body)}</li>`)
+    return
+  }
+  const checked = (task[1] ?? ' ').toLowerCase() === 'x' ? ' checked' : ''
+  // Disabled: a shared page is a copy of a document, not a place to tick
+  // things off — nothing here could record the change.
+  out.push(
+    `<li class="task"><input type="checkbox" disabled${checked}> ${inline(task[2] ?? '')}</li>`
+  )
+}
+
 /** Renders the supported subset. Never emits a tag it did not construct. */
 export function renderMarkdown(source: string): string {
   const normalized = source.split(SENTINEL).join('').replace(/\r\n?/g, '\n')
-  const lines = escapeHtml(normalized).split('\n')
+  const lines = stripFrontMatter(escapeHtml(normalized).split('\n'))
   const out: string[] = []
   const list: ListState = { tag: 'ul', open: false }
   let paragraph: string[] = []
@@ -123,7 +158,8 @@ export function renderMarkdown(source: string): string {
     closeList(out, list)
   }
 
-  for (const line of lines) {
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? ''
     if (fence) {
       // Only the same marker closes the fence, so ``` inside a ~~~ block stays
       // content rather than ending it early.
@@ -157,7 +193,15 @@ export function renderMarkdown(source: string): string {
       out.push('<hr>')
       continue
     }
-    // `>` is already escaped by the time this runs.
+    // A table only becomes one with its separator row. Without that, these are
+    // ordinary lines that happen to contain pipes.
+    const alignments = line.includes('|') ? tableAlignments(lines[index + 1] ?? '') : null
+    if (alignments) {
+      flushBlocks()
+      index = renderTable(lines, index, alignments, out)
+      continue
+    }
+    // `>` arrives escaped, which is why this matches the entity.
     const quoted = /^\s*&gt;\s?(.*)$/.exec(line)
     if (quoted) {
       flushParagraph()
@@ -170,7 +214,7 @@ export function renderMarkdown(source: string): string {
       flushParagraph()
       flushQuote()
       openList(out, list, 'ul')
-      out.push(`<li>${inline(bullet[1] ?? '')}</li>`)
+      renderListItem(bullet[1] ?? '', out)
       continue
     }
     const numbered = /^\s*\d+[.)]\s+(.*)$/.exec(line)

--- a/relay-server/src/artifacts/published-page.ts
+++ b/relay-server/src/artifacts/published-page.ts
@@ -11,6 +11,26 @@ import type { ServerResponse } from 'node:http'
 import type { ArtifactStore } from './store.js'
 
 /**
+ * The slug a request is asking for, or null when it is asking for something
+ * else entirely.
+ *
+ * Links live at the root of the artifact origin — `share.example.com/<slug>` —
+ * because that origin serves nothing but artifacts, so the short form is both
+ * available and the one people will be pasting into chat windows.
+ *
+ * Matched by exact shape rather than by a prefix: a slug is sixteen base64url
+ * characters, which cannot collide with `/v1/artifacts` or an ACME challenge,
+ * so the root namespace stays unambiguous without reserving anything.
+ *
+ * `/a/<slug>` still resolves. It is what the first release handed out, and a
+ * link someone has already shared is not ours to break.
+ */
+export function publishedSlug(path: string): string | null {
+  const match = /^\/(?:a\/)?([A-Za-z0-9_-]{16})$/.exec(path)
+  return match?.[1] ?? null
+}
+
+/**
  * Serves a published artifact.
  *
  * Unauthenticated on purpose — that is what sharing means — and every header
@@ -74,8 +94,14 @@ pre { overflow-x: auto; padding: 0.75rem 1rem; border-radius: 6px; background: r
 code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.92em; }
 pre code { font-size: 0.88em; }
 blockquote { margin: 1rem 0; padding-left: 1rem; border-left: 3px solid rgba(127,127,127,0.35); }
-img { max-width: 100%; }
-table { border-collapse: collapse; }
+img { max-width: 100%; height: auto; }
+/* Wide tables scroll inside the page rather than making the page scroll. */
+table { border-collapse: collapse; display: block; overflow-x: auto; max-width: 100%; margin: 1rem 0; }
+th, td { border: 1px solid rgba(127,127,127,0.3); padding: 0.4rem 0.7rem; text-align: left; }
+th { background: rgba(127,127,127,0.1); font-weight: 600; }
+li.task { list-style: none; margin-left: -1.2rem; }
+li.task input { margin-right: 0.4rem; }
+del { opacity: 0.65; }
 hr { border: 0; border-top: 1px solid rgba(127,127,127,0.3); margin: 2rem 0; }
 </style>
 </head>

--- a/relay-server/src/artifacts/server.ts
+++ b/relay-server/src/artifacts/server.ts
@@ -19,7 +19,7 @@ import { json } from '../shared/http-json.js'
 import { rateLimitKey } from '../shared/client-ip.js'
 import { renderMarkdown } from './markdown.js'
 import type { ArtifactRecord, ArtifactStore } from './store.js'
-import { servePublishedPage, wrapDocument } from './published-page.js'
+import { publishedSlug, servePublishedPage, wrapDocument } from './published-page.js'
 import { parseWrite, readLargeJson, REQUEST_OVERHEAD, type WriteBody } from './request-body.js'
 
 export type ArtifactServerOptions = {
@@ -38,7 +38,7 @@ export class ArtifactServer {
   constructor(private readonly options: ArtifactServerOptions) {}
 
   private shareUrl(slug: string): string {
-    return `${this.options.publicUrl}/a/${slug}`
+    return `${this.options.publicUrl}/${slug}`
   }
 
   /** The wire shape the desktop parses. Field names are its contract, not ours. */
@@ -91,8 +91,9 @@ export class ArtifactServer {
   ): Promise<boolean> {
     const url = new URL(request.url ?? '/', 'http://artifacts.local')
     const path = url.pathname
-    if (path.startsWith('/a/')) {
-      servePublishedPage(this.options.store, path.slice('/a/'.length), response)
+    const published = publishedSlug(path)
+    if (published) {
+      servePublishedPage(this.options.store, published, response)
       return true
     }
     if (path !== '/v1/artifacts' && !path.startsWith('/v1/artifacts/')) {

--- a/relay-server/src/artifacts/wiring.ts
+++ b/relay-server/src/artifacts/wiring.ts
@@ -7,6 +7,7 @@
  * the feature existed. Keeping that branch in one place is what makes it easy
  * to see that the off path allocates nothing and serves nothing.
  */
+import type { IncomingMessage } from 'node:http'
 import type { RelayConfig } from '../config.js'
 import type { AuthSessionStore } from '../auth/store.js'
 import type { Logger } from '../shared/log.js'
@@ -54,4 +55,48 @@ export function createArtifactSurface(
     limiter: deps.limiter
   })
   return { store, server }
+}
+
+/**
+ * True when this request came in on the artifact origin, and so must be served
+ * artifact routes and nothing else.
+ *
+ * That origin serves pages written by whoever published them, so auth and cell
+ * endpoints reachable there would be same-origin with hostile content — the
+ * thing the separate origin exists to stop. The proxy is supposed to enforce
+ * it; a proxy is a config file, and one written too loosely should be a
+ * mistake rather than a breach.
+ *
+ * Compared on host, which is what a browser sends and what the proxy passes
+ * through. An unset artifact origin matches nothing, so a deployment without
+ * the feature is unaffected.
+ */
+export function isArtifactHost(request: IncomingMessage, artifactPublicUrl: string): boolean {
+  if (!artifactPublicUrl) {
+    return false
+  }
+  const host = request.headers.host
+  if (!host) {
+    return false
+  }
+  try {
+    return host.toLowerCase() === new URL(artifactPublicUrl).host.toLowerCase()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Artifact gauges, or nothing when the feature is off.
+ *
+ * The byte total matters as much as the count: the operator's disk is what is
+ * at stake, and a hundred small notes and a hundred ten-megabyte pages are the
+ * same number.
+ */
+export function recordArtifactGauges(metrics: Metrics, store: ArtifactStore | null): void {
+  if (!store) {
+    return
+  }
+  metrics.gauge('manta_relay_artifacts', 'Stored artifacts.', store.size)
+  metrics.gauge('manta_relay_artifact_bytes', 'Bytes of artifact content held.', store.totalBytes)
 }

--- a/relay-server/src/config.ts
+++ b/relay-server/src/config.ts
@@ -369,10 +369,7 @@ export function loadConfig() {
       // in, and the operator is the one paying for the storage until it does.
       ttlMs: number('MANTA_RELAY_ARTIFACTS_TTL_MS', 30 * 24 * 60 * 60_000),
       maxPerAccount: number('MANTA_RELAY_ARTIFACTS_MAX_PER_ACCOUNT', 100),
-      maxTotalBytesPerAccount: number(
-        'MANTA_RELAY_ARTIFACTS_MAX_TOTAL_BYTES',
-        256 * 1024 * 1024
-      )
+      maxTotalBytesPerAccount: number('MANTA_RELAY_ARTIFACTS_MAX_TOTAL_BYTES', 256 * 1024 * 1024)
     }
   }
   assertRanges({ ...config, logLevel })

--- a/relay-server/src/relay.ts
+++ b/relay-server/src/relay.ts
@@ -20,7 +20,7 @@ import { AuthSessionStore } from './auth/store.js'
 import { AccountStore } from './auth/accounts.js'
 import { RelayDirector } from './director/server.js'
 import type { ArtifactStore } from './artifacts/store.js'
-import { createArtifactSurface } from './artifacts/wiring.js'
+import { createArtifactSurface, isArtifactHost, recordArtifactGauges } from './artifacts/wiring.js'
 import { RelayCell } from './cell/server.js'
 import { CellStore } from './cell/store.js'
 import { createRelayTokenVerifier } from './shared/relay-token.js'
@@ -173,6 +173,13 @@ export function createRelay(config: RelayConfig, logger = new Logger(config.logL
     void (async () => {
       const clientIp = clientAddress(request, trustedProxies)
       try {
+        // Artifact routes and nothing else on that name; see isArtifactHost.
+        if (artifactSurface && isArtifactHost(request, config.artifacts.publicUrl)) {
+          if (!(await artifactSurface.server.handle(request, response, clientIp))) {
+            json(response, 404, { error: 'not_found' })
+          }
+          return
+        }
         // Health is the one unauthenticated endpoint and it says only whether
         // the process is up. Session counts belong on /metrics, behind a token.
         if (request.url === '/health' || request.url === '/healthz') {
@@ -201,16 +208,7 @@ export function createRelay(config: RelayConfig, logger = new Logger(config.logL
           )
           metrics.gauge('manta_relay_auth_sessions', 'Stored auth sessions.', authSessions.size)
           metrics.gauge('manta_relay_accounts', 'Registered accounts.', accounts.size)
-          if (artifacts) {
-            // The operator's disk is the thing at stake, so the byte total
-            // matters as much as the count.
-            metrics.gauge('manta_relay_artifacts', 'Stored artifacts.', artifacts.size)
-            metrics.gauge(
-              'manta_relay_artifact_bytes',
-              'Bytes of artifact content held.',
-              artifacts.totalBytes
-            )
-          }
+          recordArtifactGauges(metrics, artifacts)
           const body = metrics.render()
           response.writeHead(200, {
             'content-type': 'text/plain; version=0.0.4',

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -324,12 +324,10 @@ function EditorPanelInner({
   const isMarkdownTableOfContentsVisible =
     markdownTableOfContentsVisible[markdownDocumentStateFileId] ?? false
   const createActiveMarkdownArtifactRequest = () =>
-    Promise.resolve(
-      createCurrentMarkdownArtifactRequest(
-        activeFile,
-        markdownDocumentStateFileId,
-        activeMarkdownContent ?? ''
-      )
+    createCurrentMarkdownArtifactRequest(
+      activeFile,
+      markdownDocumentStateFileId,
+      activeMarkdownContent ?? ''
     )
 
   return (

--- a/src/renderer/src/components/editor/MarkdownPreviewBody.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreviewBody.tsx
@@ -5,6 +5,7 @@ import rehypeHighlight from 'rehype-highlight'
 import rehypeKatex from 'rehype-katex'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
+import type { Schema } from 'hast-util-sanitize'
 import rehypeSlug from 'rehype-slug'
 import remarkBreaks from 'remark-breaks'
 import remarkFrontmatter from 'remark-frontmatter'
@@ -13,7 +14,7 @@ import remarkMath from 'remark-math'
 import { remarkMarkdownDocLinks } from './markdown-doc-links'
 import { markdownPreviewUrlTransform } from './markdown-preview-url-transform'
 
-const markdownPreviewSanitizeSchema = {
+export const markdownPreviewSanitizeSchema: Schema = {
   ...defaultSchema,
   tagNames: [...(defaultSchema.tagNames ?? []), 'details', 'summary', 'kbd', 'sub', 'sup', 'ins'],
   protocols: {
@@ -52,8 +53,8 @@ const markdownPreviewSanitizeSchema = {
   }
 }
 
-type MarkdownPluginList = NonNullable<ReactMarkdownOptions['remarkPlugins']>
-const MARKDOWN_REMARK_PLUGINS: MarkdownPluginList = [
+export type MarkdownPluginList = NonNullable<ReactMarkdownOptions['remarkPlugins']>
+export const MARKDOWN_REMARK_PLUGINS: MarkdownPluginList = [
   remarkGfm,
   remarkBreaks,
   remarkFrontmatter,
@@ -61,7 +62,7 @@ const MARKDOWN_REMARK_PLUGINS: MarkdownPluginList = [
   remarkMarkdownDocLinks
 ]
 // Why: sanitize raw HTML before KaTeX/highlight expand it.
-const MARKDOWN_REHYPE_PLUGINS: MarkdownPluginList = [
+export const MARKDOWN_REHYPE_PLUGINS: MarkdownPluginList = [
   rehypeRaw,
   [rehypeSanitize, markdownPreviewSanitizeSchema],
   rehypeSlug,

--- a/src/renderer/src/components/editor/markdown-artifact-document.tsx
+++ b/src/renderer/src/components/editor/markdown-artifact-document.tsx
@@ -1,0 +1,148 @@
+/**
+ * Renders a markdown file into the standalone page that gets shared.
+ *
+ * Why here and not on the relay: this app already renders markdown, through a
+ * pipeline that parses embedded HTML (`rehype-raw`) and then sanitizes it
+ * (`rehype-sanitize`). A relay rendering it a second time would need its own
+ * renderer and its own sanitizer, in the process that holds account
+ * credentials — and it would render *differently*, so a shared link would not
+ * match the preview it was shared from.
+ *
+ * Sharing the preview's own plugin list is the point. A second list would
+ * drift, and the promise being made is that the page someone opens is the page
+ * the author was looking at.
+ */
+import type { Options as ReactMarkdownOptions } from 'react-markdown'
+import {
+  MARKDOWN_REHYPE_PLUGINS,
+  MARKDOWN_REMARK_PLUGINS,
+  markdownPreviewSanitizeSchema
+} from './MarkdownPreviewBody'
+
+/**
+ * The preview's schema, minus `file:`.
+ *
+ * The preview allows it so a click can be authorized and opened locally. A
+ * shared page has no such handler and a different audience: a `file:///Users/…`
+ * URL in it would publish the author's directory layout to whoever opens the
+ * link, and could never resolve for them anyway.
+ */
+function shareSanitizeSchema(): typeof markdownPreviewSanitizeSchema {
+  const withoutFile = (protocols: readonly string[] | undefined): string[] =>
+    (protocols ?? []).filter((protocol) => protocol !== 'file')
+  return {
+    ...markdownPreviewSanitizeSchema,
+    protocols: {
+      ...markdownPreviewSanitizeSchema.protocols,
+      href: withoutFile(markdownPreviewSanitizeSchema.protocols?.href as string[] | undefined),
+      src: withoutFile(markdownPreviewSanitizeSchema.protocols?.src as string[] | undefined)
+    }
+  }
+}
+
+/** Swaps the preview's schema for the share one, leaving the order intact. */
+function shareRehypePlugins(): ReactMarkdownOptions['rehypePlugins'] {
+  const schema = shareSanitizeSchema()
+  return MARKDOWN_REHYPE_PLUGINS.map((plugin) =>
+    Array.isArray(plugin) && plugin[1] === markdownPreviewSanitizeSchema
+      ? [plugin[0], schema]
+      : plugin
+  ) as ReactMarkdownOptions['rehypePlugins']
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+/**
+ * The body, as HTML.
+ *
+ * `react-dom/server` and `react-markdown` are imported here rather than at the
+ * top so neither lands in the startup bundle; sharing is a deliberate action
+ * and can wait a tick for them.
+ */
+export async function renderMarkdownArtifactBody(markdown: string): Promise<string> {
+  const [{ renderToStaticMarkup }, { default: Markdown }] = await Promise.all([
+    import('react-dom/server'),
+    import('react-markdown')
+  ])
+  const rendered = renderToStaticMarkup(
+    <Markdown remarkPlugins={MARKDOWN_REMARK_PLUGINS} rehypePlugins={shareRehypePlugins()}>
+      {markdown}
+    </Markdown>
+  )
+  return tidyServerMarkup(rendered)
+}
+
+/**
+ * Removes two things React's server renderer adds that a standalone page
+ * should not carry.
+ *
+ * `<link rel="preload" as="image">` is React 19 hoisting image loads. In an
+ * app that is a speed-up; in a page handed to someone else it is a request to
+ * a third-party host fired before the reader has seen anything, which is not
+ * ours to make on their behalf.
+ *
+ * The camel-cased attribute names are React's DOM property spellings leaking
+ * into markup — `vAlign` is not an HTML attribute and browsers ignore it, so
+ * the author's alignment silently does nothing.
+ */
+function tidyServerMarkup(html: string): string {
+  return html
+    .replace(/<link\b[^>]*\brel="preload"[^>]*>/g, '')
+    .replace(
+      /\s(vAlign|charSet|colSpan|rowSpan|className|srcSet)=/g,
+      (_match, name: string) => ` ${name.toLowerCase()}=`
+    )
+    .trimStart()
+}
+
+/**
+ * A whole document: the rendered body plus enough style to be readable on its
+ * own, since nothing of this app travels with it.
+ */
+export async function renderMarkdownArtifactDocument(
+  markdown: string,
+  title: string
+): Promise<string> {
+  const body = await renderMarkdownArtifactBody(markdown)
+  return `<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<style>
+:root { color-scheme: light dark; }
+body { margin: 0 auto; padding: 2rem 1.25rem 4rem; max-width: 46rem; line-height: 1.7;
+  font: 16px/1.7 -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC",
+  "Hiragino Sans GB", "Microsoft YaHei", sans-serif; }
+h1, h2, h3, h4, h5, h6 { line-height: 1.3; margin: 2rem 0 0.75rem; }
+h1 { font-size: 1.9rem; }
+p, ul, ol, blockquote, table, pre { margin: 0 0 1rem; }
+a { color: #1f6f9c; }
+pre { overflow-x: auto; padding: 0.75rem 1rem; border-radius: 6px; background: rgba(127,127,127,0.12); }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.92em; }
+pre code { font-size: 0.88em; background: none; padding: 0; }
+:not(pre) > code { background: rgba(127,127,127,0.15); padding: 0.15em 0.35em; border-radius: 4px; }
+blockquote { margin: 1rem 0; padding-left: 1rem; border-left: 3px solid rgba(127,127,127,0.35);
+  color: rgba(127,127,127,0.95); }
+img { max-width: 100%; height: auto; }
+table { border-collapse: collapse; display: block; overflow-x: auto; max-width: 100%; }
+th, td { border: 1px solid rgba(127,127,127,0.3); padding: 0.4rem 0.7rem; }
+th { background: rgba(127,127,127,0.1); }
+hr { border: 0; border-top: 1px solid rgba(127,127,127,0.3); margin: 2rem 0; }
+ul, ol { padding-left: 1.4rem; }
+li { margin-bottom: 0.3rem; }
+</style>
+</head>
+<body>
+${body}
+</body>
+</html>
+`
+}

--- a/src/renderer/src/components/editor/markdown-artifact-upload.test.ts
+++ b/src/renderer/src/components/editor/markdown-artifact-upload.test.ts
@@ -37,14 +37,43 @@ function openFile(overrides: Partial<OpenFile> = {}): OpenFile {
 }
 
 describe('Markdown artifact upload', () => {
-  it('uses the ordinary file path for local and folder workspaces', () => {
+  it('uses the ordinary file path for local and folder workspaces', async () => {
     expect(markdownArtifactSourceKey(openFile())).toBe('/repo/notes.md')
-    expect(createMarkdownArtifactRequest(openFile(), '# Draft')).toEqual({
+    const request = await createMarkdownArtifactRequest(openFile(), '# Draft')
+    expect(request).toMatchObject({
       sourceKey: '/repo/notes.md',
-      content: '# Draft',
-      contentType: 'text/markdown',
+      contentType: 'text/html',
       fileName: 'notes.md'
     })
+    // rehype-slug adds the anchor id, same as the preview does.
+    expect(request.content).toContain('>Draft</h1>')
+  })
+
+  it('renders the embedded HTML a README opens with, rather than escaping it', async () => {
+    // The relay's own renderer escapes raw HTML, so a centred title and a row
+    // of badges arrived as a paragraph of angle brackets. This app already
+    // parses and sanitizes that HTML for the preview; sharing now carries what
+    // the preview showed.
+    const readme = [
+      '<h1 align="center">',
+      '<a href="https://example.com"><img src="https://example.com/i.png" alt="Icon" /></a> Title',
+      '</h1>',
+      '',
+      '**Body text.**'
+    ].join('\n')
+    const request = await createMarkdownArtifactRequest(openFile(), readme)
+    expect(request.content).toContain('<h1')
+    expect(request.content).toContain('<img')
+    expect(request.content).toContain('<strong>Body text.</strong>')
+    expect(request.content).not.toContain('&lt;h1')
+  })
+
+  it('drops file: URLs, which would publish paths from the author machine', async () => {
+    const request = await createMarkdownArtifactRequest(
+      openFile(),
+      '[local](file:///Users/someone/secret/notes.md)'
+    )
+    expect(request.content).not.toContain('file:///Users/someone')
   })
 
   it('isolates source identity by runtime owner', () => {
@@ -78,14 +107,21 @@ describe('Markdown artifact upload', () => {
     ).toEqual(['ssh', 'build-box', '/repo/notes.md'])
   })
 
-  it('flushes and reads the latest unsaved editor buffer', () => {
+  it('flushes and reads the latest unsaved editor buffer', async () => {
     mocks.flush.mockImplementation((fileId: string) => {
       mocks.drafts[fileId] = '# Latest edit'
     })
 
-    expect(
-      createCurrentMarkdownArtifactRequest(openFile(), '/repo/notes.md', '# Stale content').content
-    ).toBe('# Latest edit')
+    // The upload carries the rendered page now, so the buffer is checked
+    // through what it rendered into rather than by comparing the source.
+    const request = await createCurrentMarkdownArtifactRequest(
+      openFile(),
+      '/repo/notes.md',
+      '# Stale content'
+    )
+    expect(request.contentType).toBe('text/html')
+    expect(request.content).toContain('Latest edit')
+    expect(request.content).not.toContain('Stale content')
     expect(mocks.flush).toHaveBeenCalledWith('/repo/notes.md')
   })
 })

--- a/src/renderer/src/components/editor/markdown-artifact-upload.ts
+++ b/src/renderer/src/components/editor/markdown-artifact-upload.ts
@@ -29,15 +29,30 @@ export function markdownArtifactSourceKey(file: OpenFile): string {
   return file.filePath
 }
 
-export function createMarkdownArtifactRequest(
+/**
+ * Uploads the rendered page, not the markdown.
+ *
+ * The relay can render markdown, but it renders it with a small hand-written
+ * renderer that escapes embedded HTML — so a README whose first lines are a
+ * centred title and a row of badges arrived as a paragraph of angle brackets.
+ * This app already renders that file correctly, through a pipeline that parses
+ * the embedded HTML and sanitizes it, and it is the rendering the author was
+ * looking at when they pressed share.
+ *
+ * So the client renders and the server stores. The relay keeps its renderer for
+ * clients that still send markdown; nothing about the wire contract changes.
+ */
+export async function createMarkdownArtifactRequest(
   file: OpenFile,
   content: string
-): ArtifactWriteRequest {
+): Promise<ArtifactWriteRequest> {
+  const fileName = basename(file.filePath)
+  const { renderMarkdownArtifactDocument } = await import('./markdown-artifact-document')
   return {
     sourceKey: markdownArtifactSourceKey(file),
-    content,
-    contentType: 'text/markdown',
-    fileName: basename(file.filePath)
+    content: await renderMarkdownArtifactDocument(content, fileName),
+    contentType: 'text/html',
+    fileName
   }
 }
 
@@ -45,7 +60,7 @@ export function createCurrentMarkdownArtifactRequest(
   file: OpenFile,
   contentFileId: string,
   fallbackContent: string
-): ArtifactWriteRequest {
+): Promise<ArtifactWriteRequest> {
   flushPendingEditorChange(contentFileId)
   const content = useAppStore.getState().editorDrafts[contentFileId] ?? fallbackContent
   return createMarkdownArtifactRequest(file, content)


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​207 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​187 |
| Prod | 13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​485 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​117 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​368 |

<!-- /manta-pr-loc -->

Three things a first user found in an afternoon.

## Links move to the root of the artifact origin

`share.example.com/<slug>` rather than `/a/<slug>`. That origin serves nothing
but artifacts, so the short form was always available, and it is the one people
paste into a chat window.

A slug is sixteen base64url characters, matched by shape rather than by a
prefix, so the root namespace stays unambiguous beside the write API without
reserving anything. **`/a/` still resolves** — it is what the first release
handed out, and a shared link is not ours to break.

## The renderer covered too little of a real markdown file

| Input | Was | Now |
| --- | --- | --- |
| YAML front matter | a rule, then a paragraph of YAML | dropped |
| Tables | one collapsed paragraph | a table, with alignments |
| `![alt](src)` | a link with a stray `!` | an image |
| `- [ ]` / `- [x]` | literal brackets | disabled checkboxes |
| `~~text~~` | nothing | strikethrough |

A note whose first lines are `title:` and `tags:` looked broken before its
first heading, which is what sent someone looking for a bug.

The invariant is unchanged: every byte is still escaped before any rule runs,
so a table cell cannot smuggle a tag out either — there is a test for exactly
that. Raw HTML in markdown is still shown as text; that is the cost of having
no sanitizer to bypass, and the way around it is to publish an HTML artifact,
which is served verbatim.

## The relay now enforces its own origin rule

Auth, cell, and health routes are refused when the request arrives on the
artifact origin.

The proxy was always supposed to prevent that. I wrote one that did not:
reaching for a single broad `reverse_proxy` put `/v1/desktop/auth/*` on the
origin that serves pages written by whoever published them — the exact thing a
separate origin exists to stop. A proxy is a config file, and the relay should
not depend on every one of them being written tightly.

The test drives it with a raw `http.request`, because `fetch` treats `Host` as
a forbidden header and drops it silently: written with fetch, the test would
have passed against a relay that ignored the origin entirely, having never sent
the header it was testing. It fails with the guard removed.

## Verification

250 relay tests. Deployed and checked against the live host: `POST
/v1/artifacts` on the artifact origin is 401, `/v1/desktop/auth/methods` and
`/health` there are 404, and the relay's own name still answers both.