### PR TITLE
fix(release): name a release after the upstream it merged, not the one upstream published

### DIFF
--- a/config/scripts/cut-fork-release.mjs
+++ b/config/scripts/cut-fork-release.mjs
@@ -174,6 +174,63 @@ async function upstreamStableBase() {
   return { desktop: tag.replace(/^v/, ''), mobile: upstreamMobileVersion(releases) }
 }
 
+/**
+ * Upstream's version at the commit `refs/sync/base` mirrors.
+ *
+ * That ref is what the sync moves when a merge lands, and its `Mirror-Of`
+ * trailer names the upstream commit it mirrors — so upstream's own manifest at
+ * that commit is exactly the version this fork is built on.
+ *
+ * Null when the ref or the commit is missing, which is a clone that has never
+ * synced; the caller falls back to upstream's published version rather than
+ * refusing to cut.
+ */
+/**
+ * The upstream version this release is named after.
+ *
+ * `merged` is what the fork has actually taken from upstream; `published` is
+ * what upstream has released. They diverge for as long as a sync is
+ * outstanding, and naming a release after `published` names it after work it
+ * does not contain — upstream tagged 1.4.198 while this tree was 394 commits
+ * behind it, and the cut produced 1.4.198-rc.0 whose own notes said upstream
+ * was unchanged.
+ *
+ * `published` is only the fallback for a clone that has never synced and so
+ * has nothing better to go on. And never backwards: a fork-only fix cut ahead
+ * of upstream keeps the base it already had.
+ */
+export function releaseBase(merged, published, currentBase) {
+  const upstreamBase = merged ?? published
+  return compareBases(upstreamBase, currentBase) > 0 ? upstreamBase : currentBase
+}
+
+function mergedUpstreamBase() {
+  try {
+    const message = execFileSync('git', ['log', '-1', '--format=%B', 'refs/sync/base'], {
+      cwd: root,
+      encoding: 'utf8'
+    })
+    // The last trailer, not the first: a mirror commit carries its own
+    // Mirror-Of and may quote earlier ones in the body above it.
+    const mirrorOf = message
+      .split('\n')
+      .toReversed()
+      .map((line) => /^Mirror-Of:\s*(\S+)/.exec(line)?.[1])
+      .find(Boolean)
+    if (!mirrorOf) {
+      return null
+    }
+    const manifest = execFileSync('git', ['show', `${mirrorOf}:package.json`], {
+      cwd: root,
+      encoding: 'utf8'
+    })
+    const version = JSON.parse(manifest).version
+    return typeof version === 'string' ? version.split('-')[0] : null
+  } catch {
+    return null
+  }
+}
+
 function compareBases(a, b) {
   const left = a.split('.').map(Number)
   const right = b.split('.').map(Number)
@@ -274,8 +331,13 @@ async function main() {
   const currentBase = manifest.version.split('-')[0]
 
   const upstream = await upstreamStableBase()
-  // Never backwards: a fork-only fix cut ahead of upstream keeps its base.
-  const base = compareBases(upstream.desktop, currentBase) > 0 ? upstream.desktop : currentBase
+  // The upstream version this fork has actually merged, not the newest one
+  // upstream has published. Those differ for as long as a sync is outstanding,
+  // and taking the published one names a release after work it does not
+  // contain: upstream tagged 1.4.198 while this tree was 394 commits behind it,
+  // and the cut produced 1.4.198-rc.0 whose own notes said upstream was
+  // unchanged. The version can only move when a sync moves it.
+  const base = releaseBase(mergedUpstreamBase(), upstream.desktop, currentBase)
   let version = value('--version')
   if (!version) {
     const highest = highestRcForBase(base, { cwd: root })

--- a/config/scripts/cut-fork-release.test.mjs
+++ b/config/scripts/cut-fork-release.test.mjs
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest'
 
 import { highestRcForBase } from './release-rc-history.mjs'
 import { latestStableDesktopReleaseTag } from './latest-stable-release.mjs'
-import { bumpMobileAppConfig, upstreamMobileVersion } from './cut-fork-release.mjs'
+import { bumpMobileAppConfig, upstreamMobileVersion, releaseBase } from './cut-fork-release.mjs'
 import { draftReleaseNotes } from './release-notes-draft.mjs'
 
 /**
@@ -199,5 +199,27 @@ describe('mobile app config bump', () => {
       '"plugins": [["expo-build-properties", { "version": "1.2.3" }]],'
     )
     expect(() => bumpMobileAppConfig(ambiguous, '0.0.47')).toThrow(/matched 2 times/)
+  })
+})
+
+describe('releaseBase', () => {
+  it('names the release after what the fork merged, not what upstream published', () => {
+    // Upstream tagged 1.4.198 while this tree was 394 commits behind it. Taking
+    // the published version produced 1.4.198-rc.0 whose own notes said upstream
+    // was unchanged since the last release — the number claiming work the
+    // release did not contain.
+    expect(releaseBase('1.4.197', '1.4.198', '1.4.197')).toBe('1.4.197')
+  })
+
+  it('advances once a sync has actually merged the newer upstream', () => {
+    expect(releaseBase('1.4.198', '1.4.198', '1.4.197')).toBe('1.4.198')
+  })
+
+  it('falls back to the published version when nothing has ever been synced', () => {
+    expect(releaseBase(null, '1.4.198', '1.4.197')).toBe('1.4.198')
+  })
+
+  it('never moves backwards from a fork-only cut made ahead of upstream', () => {
+    expect(releaseBase('1.4.197', '1.4.197', '1.4.198')).toBe('1.4.198')
   })
 })


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​64 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​62 |

<!-- /manta-pr-loc -->

Cutting a release today produced **1.4.198-rc.0** from a tree 394 commits behind
upstream — and its own generated notes read *"upstream is unchanged since the
last release"*. The number claimed work the release did not contain, and the
next real sync would have had nowhere honest to go.

The base came from upstream's newest published version. That is only the same
as this fork's base immediately after a sync; for as long as one is
outstanding, the two diverge and the published number is the wrong one.

It now comes from `refs/sync/base` — the ref a sync moves when a merge lands —
by reading upstream's own manifest at the commit its `Mirror-Of` trailer names.
That is the upstream version this fork is actually built on, so the release
number can only advance when a sync advances it.

Upstream's published version stays as the fallback for a clone that has never
synced and has nothing better to go on.

The decision is a pure function so it can be tested; the git reading around it
is not the part that was wrong. Four cases, and the first fails if the old
behaviour is restored.