### PR TITLE
fix(share): carry a shared page's images with it, give it an icon, and point install links at a repository that exists

### DIFF
--- a/config/scripts/latest-stable-release.mjs
+++ b/config/scripts/latest-stable-release.mjs
@@ -78,7 +78,7 @@ export async function fetchReleases(repo, token, fetchImpl = fetch) {
 
 async function main() {
   const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN
-  const repo = process.env.GITHUB_REPOSITORY || 'stablyai/manta'
+  const repo = process.env.GITHUB_REPOSITORY || 'paidaxingyo666/Manta'
   const releases = await fetchReleases(repo, token)
   process.stdout.write(latestStableDesktopReleaseTag(releases))
 }

--- a/config/scripts/locale-ko-key-overrides.json
+++ b/config/scripts/locale-ko-key-overrides.json
@@ -4569,7 +4569,7 @@
     "ko": "합계"
   },
   "auto.components.stats.share.card.utils.19f4b4dc75": {
-    "ko": "github.com/stablyai/manta"
+    "ko": "github.com/paidaxingyo666/Manta"
   },
   "auto.components.stats.share.card.utils.7080aeaebb": {
     "ko": "추론"

--- a/config/scripts/macos-launch-diagnostics.sh
+++ b/config/scripts/macos-launch-diagnostics.sh
@@ -6,7 +6,7 @@
 #   bash config/scripts/macos-launch-diagnostics.sh --tag v1.4.42-rc.1
 set -euo pipefail
 
-REPO="${MANTA_DIAGNOSTIC_REPO:-stablyai/manta}"
+REPO="${MANTA_DIAGNOSTIC_REPO:-paidaxingyo666/Manta}"
 TAG="${MANTA_DIAGNOSTIC_TAG:-}"
 KEEP=0
 

--- a/config/scripts/publish-complete-draft-releases.mjs
+++ b/config/scripts/publish-complete-draft-releases.mjs
@@ -157,7 +157,7 @@ export function writeGithubOutputs({ published, skipped }, outputPath = process.
 
 async function main() {
   const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN
-  const repo = process.env.GITHUB_REPOSITORY || 'stablyai/manta'
+  const repo = process.env.GITHUB_REPOSITORY || 'paidaxingyo666/Manta'
   const result = await publishCompleteDraftReleases({ repo, token })
   writeGithubOutputs(result)
 }

--- a/mobile/src/components/HostProtocolGate.test.ts
+++ b/mobile/src/components/HostProtocolGate.test.ts
@@ -119,7 +119,7 @@ describe('HostProtocolGate', () => {
     expect(output).not.toContain('HostContent')
     act(() => renderer?.root.findAllByType('Pressable')[0]?.props.onPress())
     expect(nativeTestState.openUrl).toHaveBeenCalledWith(
-      'https://github.com/stablyai/manta/releases'
+      'https://github.com/paidaxingyo666/Manta/releases'
     )
   })
 

--- a/mobile/src/components/ProtocolBlockScreen.tsx
+++ b/mobile/src/components/ProtocolBlockScreen.tsx
@@ -4,7 +4,7 @@ import { colors, radii, spacing, typography } from '../theme/mobile-theme'
 import type { CompatVerdict } from '../transport/protocol-compat'
 import { translate } from '../i18n/i18n'
 
-const RELEASES_URL = 'https://github.com/stablyai/manta/releases'
+const RELEASES_URL = 'https://github.com/paidaxingyo666/Manta/releases'
 const IOS_APP_STORE_URL = 'itms-apps://apps.apple.com/app/orca-ide/id6766130217'
 
 type Props = {

--- a/relay-server/src/artifacts.test.ts
+++ b/relay-server/src/artifacts.test.ts
@@ -257,6 +257,41 @@ describe('publishing', () => {
     expect(html).not.toContain('<script>')
     expect(html).toContain('&lt;script&gt;')
   })
+
+  it('serves a tab icon on the artifact origin, for both page kinds', async () => {
+    current = await startWithArtifacts()
+    const token = await signIn(current.origin)
+    const icon = await fetch(`${current.origin}/favicon.ico`)
+    expect(icon.status).toBe(200)
+    expect(icon.headers.get('content-type')).toContain('image/svg+xml')
+    expect(await icon.text()).toContain('<svg')
+
+    // An HTML artifact is published verbatim, so the browser's own request for
+    // /favicon.ico is the only way it can get an icon at all.
+    const html = (await (
+      await api(current.origin, '', token, { method: 'POST', body: HTML_BODY })
+    ).json()) as Created
+    const served = await fetch(`${current.origin}/${html.artifact.slug}`)
+    expect(await served.text()).not.toContain('rel="icon"')
+
+    // A rendered markdown page is wrapped, so it says which icon to use rather
+    // than leaving the browser to guess at a path.
+    const note = (await (
+      await api(current.origin, '', token, {
+        method: 'POST',
+        body: { content: '# Note', contentType: 'text/markdown', fileName: 'note.md' }
+      })
+    ).json()) as Created
+    const page = await fetch(`${current.origin}/${note.artifact.slug}`)
+    expect(await page.text()).toContain('<link rel="icon" href="/favicon.ico"')
+  })
+
+  it('does not spend an artifact rate limit on the tab icon', async () => {
+    current = await startWithArtifacts()
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      expect((await fetch(`${current.origin}/favicon.ico`)).status).toBe(200)
+    }
+  })
 })
 
 describe('authorization', () => {

--- a/relay-server/src/artifacts/favicon.ts
+++ b/relay-server/src/artifacts/favicon.ts
@@ -1,0 +1,31 @@
+/**
+ * The tab icon for every page this origin serves.
+ *
+ * Served as a route rather than only declared in `wrapDocument`, because an
+ * HTML artifact is published verbatim and never wrapped — its author's markup
+ * is the whole document, so the only icon it can pick up is the one a browser
+ * asks for on its own at `/favicon.ico`. A route covers both page kinds; a
+ * `<link>` would cover one.
+ *
+ * SVG, despite the `.ico` name: the extension is not what a browser reads, the
+ * content type is, and one 2 KB vector serves every density. It carries its own
+ * `prefers-color-scheme` rule so the mark stays legible on a light and a dark
+ * tab strip alike.
+ */
+import type { ServerResponse } from 'node:http'
+
+export const FAVICON_PATH = '/favicon.ico'
+
+const FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 320"><style>.bg{fill:#171717}.mark{fill:#fafafa}@media(prefers-color-scheme:dark){.bg{fill:#fafafa}.mark{fill:#171717}}</style><rect class="bg" width="320" height="320" rx="68"/><path class="mark" transform="translate(33.35,30.34) scale(0.7536)" d="m 177.81311,248.33334 c 23.82304,-41.29793 40.54045,-66.84626 49.51207,-75.66667 6.81685,-6.70196 10.07373,-8.7374 20.07265,-12.54475 34.57822,-13.16655 61.04674,-26.78733 72.37222,-37.24295 9.62924,-8.88966 9.34286,-9.01142 -23.43671,-9.964 -35.71756,-1.03796 -43.72989,0.42119 -62.17546,11.323 -16.72118,9.88265 -34.20103,30.11225 -42.74704,49.47157 -2.57353,5.82985 -14.81294,44.3056 -27.96399,87.90747 -2.86036,9.48343 -3.02466,11.71633 -0.86213,11.71633 0.44382,0 7.29659,-11.25 15.22839,-25 z m -65.14644,-8.32267 C 120,239.3326 130.5,237.50979 136,235.95998 c 5.5,-1.5498 12.25,-3.13783 15,-3.52895 2.75,-0.39111 5,-0.95485 5,-1.25275 0,-0.29789 2.15135,-7.58487 4.78078,-16.19328 8.49209,-27.80201 12.21334,-40.41629 21.13747,-71.65166 4.81891,-16.86667 11.23502,-39.185 14.25802,-49.596301 5.12803,-17.66103 5.74763,-23.07037 2.64253,-23.07037 -1.84887,0 -4.07048,6.908293 -16.72243,52.000001 -21.78975,77.65896 -20.80806,74.74393 -26.84794,79.72251 -7.5925,6.25838 -25.03916,14.82524 -36.10856,17.73044 -17.0947,4.48656 -33.410599,3.86724 -53.116765,-2.01622 -18.569242,-5.54403 -23.142662,-5.80284 -33.639754,-1.9037 -5.875424,2.18242 -9.864152,5.04363 -16.716684,11.99127 -4.95,5.0187 -9.0000001,10.02884 -9.0000001,11.13364 0,1.75174 5.9276921,2.00299 46.3333351,1.96383 25.483334,-0.0247 52.333338,-0.59969 59.666668,-1.27777 z M 252.69513,104.63708 c 12.18267,-3.48651 15.77304,-7.895503 9.63821,-11.835773 -10.19296,-6.546726 -36.19849,-1.77301 -41.19436,7.561863 -1.2556,2.3461 -0.98698,3.2037 1.68353,5.375 2.69471,2.19098 4.59991,2.47691 12.53928,1.88189 5.14899,-0.3859 12.94899,-1.72824 17.33334,-2.98298 z"/></svg>`
+
+export function serveFavicon(response: ServerResponse): void {
+  response.writeHead(200, {
+    'content-type': 'image/svg+xml; charset=utf-8',
+    'content-length': Buffer.byteLength(FAVICON_SVG),
+    // Unlike an artifact body, this never changes for a given build, and a tab
+    // icon re-fetched on every page view is a request per artifact opened.
+    'cache-control': 'public, max-age=86400',
+    'x-content-type-options': 'nosniff'
+  })
+  response.end(FAVICON_SVG)
+}

--- a/relay-server/src/artifacts/published-page.ts
+++ b/relay-server/src/artifacts/published-page.ts
@@ -85,6 +85,7 @@ export function wrapDocument(title: string, html: string): string {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="icon" href="/favicon.ico" type="image/svg+xml">
 <title>${safeTitle}</title>
 <style>
 :root { color-scheme: light dark; }

--- a/relay-server/src/artifacts/server.ts
+++ b/relay-server/src/artifacts/server.ts
@@ -19,6 +19,7 @@ import { json } from '../shared/http-json.js'
 import { rateLimitKey } from '../shared/client-ip.js'
 import { renderMarkdown } from './markdown.js'
 import type { ArtifactRecord, ArtifactStore } from './store.js'
+import { FAVICON_PATH, serveFavicon } from './favicon.js'
 import { publishedSlug, servePublishedPage, wrapDocument } from './published-page.js'
 import { parseWrite, readLargeJson, REQUEST_OVERHEAD, type WriteBody } from './request-body.js'
 
@@ -94,6 +95,13 @@ export class ArtifactServer {
     const published = publishedSlug(path)
     if (published) {
       servePublishedPage(this.options.store, published, response)
+      return true
+    }
+    // Before the rate limiter on purpose: a browser asks for this once per page
+    // it opens, and spending an artifact's budget on its own tab icon is how a
+    // reader who opened a few links gets a 429 on the next one.
+    if (path === FAVICON_PATH) {
+      serveFavicon(response)
       return true
     }
     if (path !== '/v1/artifacts' && !path.startsWith('/v1/artifacts/')) {

--- a/src/cli/skills.test.ts
+++ b/src/cli/skills.test.ts
@@ -339,7 +339,7 @@ describe('manta skills CLI', () => {
     await main(['skills', 'install', '--skill', 'alpha', '--dry-run'], '/tmp/repo')
 
     expect(stdoutText(stdoutSpy)).toBe(
-      'npx --yes skills add https://github.com/stablyai/manta --skill alpha --global --agent claude-code --agent universal -y\n\n' +
+      'npx --yes skills add https://github.com/paidaxingyo666/Manta --skill alpha --global --agent claude-code --agent universal -y\n\n' +
         'Rerun without --dry-run to install now.\n'
     )
     expect(spawnMock).not.toHaveBeenCalled()
@@ -354,7 +354,7 @@ describe('manta skills CLI', () => {
       `${JSON.stringify(
         {
           command:
-            'npx --yes skills add https://github.com/stablyai/manta --skill alpha --global --agent claude-code --agent universal -y',
+            'npx --yes skills add https://github.com/paidaxingyo666/Manta --skill alpha --global --agent claude-code --agent universal -y',
           skills: ['alpha'],
           global: true,
           executed: false
@@ -371,7 +371,7 @@ describe('manta skills CLI', () => {
     await main(['skills', 'install', '--skill', 'alpha', '--local', '--dry-run'], '/tmp/repo')
 
     expect(stdoutText(stdoutSpy)).toBe(
-      'npx --yes skills add https://github.com/stablyai/manta --skill alpha --agent claude-code --agent universal -y\n\n' +
+      'npx --yes skills add https://github.com/paidaxingyo666/Manta --skill alpha --agent claude-code --agent universal -y\n\n' +
         'Rerun without --dry-run to install now.\n'
     )
 
@@ -385,7 +385,7 @@ describe('manta skills CLI', () => {
       `${JSON.stringify(
         {
           command:
-            'npx --yes skills add https://github.com/stablyai/manta --skill alpha --agent claude-code --agent universal -y',
+            'npx --yes skills add https://github.com/paidaxingyo666/Manta --skill alpha --agent claude-code --agent universal -y',
           skills: ['alpha'],
           global: false,
           executed: false
@@ -412,7 +412,7 @@ describe('manta skills CLI', () => {
         '--yes',
         'skills',
         'add',
-        'https://github.com/stablyai/manta',
+        'https://github.com/paidaxingyo666/Manta',
         '--skill',
         'alpha',
         '--agent',
@@ -447,7 +447,7 @@ describe('manta skills CLI', () => {
         '--yes',
         'skills',
         'add',
-        'https://github.com/stablyai/manta',
+        'https://github.com/paidaxingyo666/Manta',
         '--skill',
         'alpha',
         '--global',
@@ -495,7 +495,7 @@ describe('manta skills CLI', () => {
         '--yes',
         'skills',
         'add',
-        'https://github.com/stablyai/manta',
+        'https://github.com/paidaxingyo666/Manta',
         '--skill',
         'alpha',
         '--global',
@@ -525,7 +525,7 @@ describe('manta skills CLI', () => {
         '--yes',
         'skills',
         'add',
-        'https://github.com/stablyai/manta',
+        'https://github.com/paidaxingyo666/Manta',
         '--skill',
         'alpha',
         '--skill',
@@ -897,7 +897,7 @@ describe('manta skills CLI', () => {
         '--yes',
         'skills',
         'add',
-        'https://github.com/stablyai/manta',
+        'https://github.com/paidaxingyo666/Manta',
         '--skill',
         'alpha',
         '--skill',
@@ -922,7 +922,7 @@ describe('manta skills CLI', () => {
     )
 
     expect(stdoutText(stdoutSpy)).toBe(
-      'npx --yes skills add https://github.com/stablyai/manta --skill alpha --global --agent claude-code --agent universal -y\n\n' +
+      'npx --yes skills add https://github.com/paidaxingyo666/Manta --skill alpha --global --agent claude-code --agent universal -y\n\n' +
         'Rerun without --dry-run to install now.\n'
     )
     expect(spawnMock).not.toHaveBeenCalled()
@@ -940,7 +940,7 @@ describe('manta skills CLI', () => {
 
     // Why: stdout belongs to the child, so this record has to go to stderr.
     expect(stderrSpy).toHaveBeenCalledWith(
-      'Running: npx --yes skills add https://github.com/stablyai/manta --skill alpha --global --agent claude-code --agent universal -y\n'
+      'Running: npx --yes skills add https://github.com/paidaxingyo666/Manta --skill alpha --global --agent claude-code --agent universal -y\n'
     )
   })
 

--- a/src/main/telemetry/onboarding-feature-setup-validator.test.ts
+++ b/src/main/telemetry/onboarding-feature-setup-validator.test.ts
@@ -49,7 +49,7 @@ describe('onboarding feature setup telemetry validation', () => {
         linear_tickets: false,
         orchestration: true,
         selected_count: 2,
-        command: 'npx skills add https://github.com/stablyai/manta --global'
+        command: 'npx skills add https://github.com/paidaxingyo666/Manta --global'
       } as never).ok
     ).toBe(false)
     expect(

--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -25,7 +25,7 @@ type ShortcutItem = {
 }
 
 // Do not deep-link to /stargazers: GitHub 404s that page for users without repo write access.
-const MANTA_GITHUB_URL = 'https://github.com/stablyai/manta'
+const MANTA_GITHUB_URL = 'https://github.com/paidaxingyo666/Manta'
 
 type StarButtonProps = {
   hasRepos: boolean

--- a/src/renderer/src/components/StarNagCard.tsx
+++ b/src/renderer/src/components/StarNagCard.tsx
@@ -6,7 +6,7 @@ import { useAppStore } from '../store'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
 
-const MANTA_REPO_URL = 'https://github.com/stablyai/manta'
+const MANTA_REPO_URL = 'https://github.com/paidaxingyo666/Manta'
 type StarNagMode = 'gh' | 'web'
 
 /**

--- a/src/renderer/src/components/editor/markdown-artifact-document.tsx
+++ b/src/renderer/src/components/editor/markdown-artifact-document.tsx
@@ -18,6 +18,15 @@ import {
   MARKDOWN_REMARK_PLUGINS,
   markdownPreviewSanitizeSchema
 } from './MarkdownPreviewBody'
+import {
+  buildArtifactImageDataUris,
+  collectArtifactImageSources,
+  rehypeInlineArtifactImages,
+  type ArtifactImageContext
+} from './markdown-artifact-image-inlining'
+
+/** What the page is being rendered from, so its images can travel with it. */
+export type MarkdownArtifactSource = ArtifactImageContext & { filePath: string }
 
 /**
  * The preview's schema, minus `file:`.
@@ -35,18 +44,36 @@ function shareSanitizeSchema(): typeof markdownPreviewSanitizeSchema {
     protocols: {
       ...markdownPreviewSanitizeSchema.protocols,
       href: withoutFile(markdownPreviewSanitizeSchema.protocols?.href as string[] | undefined),
-      src: withoutFile(markdownPreviewSanitizeSchema.protocols?.src as string[] | undefined)
+      // `data:` for what the inlining step just put there. `img` is the only
+      // element this schema gives a `src` to, and a data URI in one is rendered
+      // as an image and nothing else — an SVG loaded that way does not script.
+      src: [
+        ...withoutFile(markdownPreviewSanitizeSchema.protocols?.src as string[] | undefined),
+        'data'
+      ]
     }
   }
 }
 
-/** Swaps the preview's schema for the share one, leaving the order intact. */
-function shareRehypePlugins(): ReactMarkdownOptions['rehypePlugins'] {
+/**
+ * Swaps the preview's schema for the share one, leaving the order intact, and
+ * puts the image rewrite immediately before it.
+ *
+ * `null` renders with the preview's own schema instead: that pass exists only
+ * to find which images the document refers to, and it has to keep the `file:`
+ * URLs the share schema is there to remove.
+ */
+function shareRehypePlugins(
+  inlined: ReadonlyMap<string, string> | null
+): ReactMarkdownOptions['rehypePlugins'] {
+  if (!inlined) {
+    return MARKDOWN_REHYPE_PLUGINS as ReactMarkdownOptions['rehypePlugins']
+  }
   const schema = shareSanitizeSchema()
-  return MARKDOWN_REHYPE_PLUGINS.map((plugin) =>
+  return MARKDOWN_REHYPE_PLUGINS.flatMap((plugin) =>
     Array.isArray(plugin) && plugin[1] === markdownPreviewSanitizeSchema
-      ? [plugin[0], schema]
-      : plugin
+      ? [rehypeInlineArtifactImages(inlined), [plugin[0], schema]]
+      : [plugin]
   ) as ReactMarkdownOptions['rehypePlugins']
 }
 
@@ -65,17 +92,31 @@ function escapeHtml(value: string): string {
  * top so neither lands in the startup bundle; sharing is a deliberate action
  * and can wait a tick for them.
  */
-export async function renderMarkdownArtifactBody(markdown: string): Promise<string> {
+export async function renderMarkdownArtifactBody(
+  markdown: string,
+  source?: MarkdownArtifactSource
+): Promise<string> {
   const [{ renderToStaticMarkup }, { default: Markdown }] = await Promise.all([
     import('react-dom/server'),
     import('react-markdown')
   ])
-  const rendered = renderToStaticMarkup(
-    <Markdown remarkPlugins={MARKDOWN_REMARK_PLUGINS} rehypePlugins={shareRehypePlugins()}>
-      {markdown}
-    </Markdown>
-  )
-  return tidyServerMarkup(rendered)
+  const render = (inlined: ReadonlyMap<string, string> | null): string =>
+    renderToStaticMarkup(
+      <Markdown remarkPlugins={MARKDOWN_REMARK_PLUGINS} rehypePlugins={shareRehypePlugins(inlined)}>
+        {markdown}
+      </Markdown>
+    )
+  // Twice, because the images have to be read before the tree that carries them
+  // is built and there is no asynchronous step inside react-markdown's pipeline
+  // to read them from. The first pass is a discovery render whose output is
+  // thrown away; sharing is a deliberate action and can afford it.
+  const inlined = source
+    ? await buildArtifactImageDataUris(collectArtifactImageSources(render(null)), source.filePath, {
+        connectionId: source.connectionId,
+        runtimeContext: source.runtimeContext
+      })
+    : new Map<string, string>()
+  return tidyServerMarkup(render(inlined))
 }
 
 /**
@@ -107,9 +148,10 @@ function tidyServerMarkup(html: string): string {
  */
 export async function renderMarkdownArtifactDocument(
   markdown: string,
-  title: string
+  title: string,
+  source?: MarkdownArtifactSource
 ): Promise<string> {
-  const body = await renderMarkdownArtifactBody(markdown)
+  const body = await renderMarkdownArtifactBody(markdown, source)
   return `<!doctype html>
 <html lang="zh-CN">
 <head>

--- a/src/renderer/src/components/editor/markdown-artifact-image-inlining.ts
+++ b/src/renderer/src/components/editor/markdown-artifact-image-inlining.ts
@@ -1,0 +1,151 @@
+/**
+ * Carries a shared page's images with it, as data URIs.
+ *
+ * A shared page is a single stored document and nothing else, so an image the
+ * author sees locally has no way to reach a reader: `file:///Users/…` is theirs
+ * alone, and `./shots/a.png` resolves against the artifact origin, which has no
+ * such file. Both arrive as a broken image with no hint of why.
+ *
+ * Reading the bytes at share time and inlining them makes the page
+ * self-contained — no second store to provision, no lifetime to reconcile
+ * against the artifact's own, no orphan to collect when a page is replaced.
+ * Remote and http images are already portable and are left exactly as written.
+ */
+import { resolveImageAbsolutePath } from './markdown-preview-links'
+import { readLocalImagePreview } from './local-image-src-reader'
+import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
+
+export type ArtifactImageContext = {
+  connectionId?: string | null
+  runtimeContext?:
+    | (Omit<RuntimeFileOperationArgs, 'connectionId'> & { connectionId?: string | null })
+    | null
+}
+
+/**
+ * How much encoded image a page may carry.
+ *
+ * The relay's own ceiling is 10 MB for the whole artifact; base64 costs a third
+ * on top of the bytes, and the prose still has to fit. Six leaves room for both
+ * and is far more than a document of screenshots needs.
+ */
+const MAX_INLINE_BYTES = 6 * 1024 * 1024
+
+/** Already portable: it resolves the same for a reader as for the author. */
+function isPortable(src: string): boolean {
+  return /^(?:https?:|data:)/i.test(src)
+}
+
+/**
+ * Every `src` on an `<img>` in rendered HTML.
+ *
+ * Reading, not securing — what may appear in the published page is still
+ * decided by the sanitizer, which runs after this on a real element tree. A
+ * regex here only has to find candidates to go and read.
+ */
+export function collectArtifactImageSources(html: string): string[] {
+  const found = new Set<string>()
+  for (const tag of html.match(/<img\b[^>]*>/gi) ?? []) {
+    const src = /\ssrc="([^"]*)"/i.exec(tag)?.[1]
+    if (src && !isPortable(src)) {
+      found.add(decodeHtmlEntities(src))
+    }
+  }
+  return [...found]
+}
+
+/** React escapes attribute values; the raw src is what the resolver needs. */
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;|&#39;/g, "'")
+    .replace(/&amp;/g, '&')
+}
+
+/**
+ * Reads what it can and reports what it could not, keyed by the src as written.
+ *
+ * A file that has moved, is not an image, or would push the page past the
+ * budget is left out rather than failing the share: the sanitizer then drops
+ * its unresolvable `src` and the browser shows the alt text, which says more to
+ * a reader than a broken-image icon does.
+ */
+export async function buildArtifactImageDataUris(
+  sources: readonly string[],
+  filePath: string,
+  context: ArtifactImageContext = {}
+): Promise<Map<string, string>> {
+  const inlined = new Map<string, string>()
+  let budget = MAX_INLINE_BYTES
+  for (const src of sources) {
+    const absolutePath = resolveImageAbsolutePath(src, filePath)
+    if (!absolutePath) {
+      continue
+    }
+    const dataUri = await readAsDataUri(absolutePath, context)
+    if (!dataUri || dataUri.length > budget) {
+      continue
+    }
+    budget -= dataUri.length
+    inlined.set(src, dataUri)
+  }
+  return inlined
+}
+
+type HastNode = {
+  type: string
+  tagName?: string
+  properties?: Record<string, unknown>
+  children?: HastNode[]
+}
+
+/**
+ * Swaps in the data URIs, before the sanitizer runs.
+ *
+ * Order is the whole safety argument. This only rewrites; what survives into
+ * the page is still the sanitizer's decision, so an image that could not be
+ * read keeps the `file:` or relative `src` it was written with and is dropped
+ * there, exactly as it would have been without this step. Nothing here can
+ * widen what a shared page is allowed to carry.
+ */
+export function rehypeInlineArtifactImages(inlined: ReadonlyMap<string, string>) {
+  return () =>
+    (tree: HastNode): void => {
+      const visit = (node: HastNode): void => {
+        if (node.tagName === 'img' && node.properties) {
+          const src = node.properties.src
+          if (typeof src === 'string') {
+            const dataUri = inlined.get(src)
+            if (dataUri) {
+              node.properties.src = dataUri
+            }
+          }
+        }
+        for (const child of node.children ?? []) {
+          visit(child)
+        }
+      }
+      visit(tree)
+    }
+}
+
+async function readAsDataUri(
+  absolutePath: string,
+  context: ArtifactImageContext
+): Promise<string | null> {
+  try {
+    const result = await readLocalImagePreview(
+      absolutePath,
+      context.connectionId,
+      context.runtimeContext ?? undefined
+    )
+    if (!result.isBinary || !result.content) {
+      return null
+    }
+    return `data:${result.mimeType ?? 'image/png'};base64,${result.content.replace(/\s/g, '')}`
+  } catch {
+    return null
+  }
+}

--- a/src/renderer/src/components/editor/markdown-artifact-upload.test.ts
+++ b/src/renderer/src/components/editor/markdown-artifact-upload.test.ts
@@ -8,11 +8,20 @@ import {
 
 const mocks = vi.hoisted(() => ({
   drafts: {} as Record<string, string>,
-  flush: vi.fn()
+  flush: vi.fn(),
+  settings: undefined as unknown,
+  worktreesByRepo: {} as Record<string, unknown[]>
 }))
 
 vi.mock('@/store', () => ({
-  useAppStore: { getState: () => ({ editorDrafts: mocks.drafts }) }
+  useAppStore: {
+    getState: () => ({
+      editorDrafts: mocks.drafts,
+      settings: mocks.settings,
+      folderWorkspaces: [],
+      worktreesByRepo: mocks.worktreesByRepo
+    })
+  }
 }))
 vi.mock('./editor-pending-flush', () => ({
   flushPendingEditorChange: mocks.flush
@@ -20,6 +29,7 @@ vi.mock('./editor-pending-flush', () => ({
 
 beforeEach(() => {
   mocks.drafts = {}
+  mocks.worktreesByRepo = {}
   mocks.flush.mockReset()
 })
 

--- a/src/renderer/src/components/editor/markdown-artifact-upload.ts
+++ b/src/renderer/src/components/editor/markdown-artifact-upload.ts
@@ -2,9 +2,13 @@ import type { ArtifactWriteRequest } from '../../../../shared/artifacts'
 import { sshArtifactSourceKey } from '../../../../shared/artifact-cli-bridge'
 import { parseExecutionHostId } from '../../../../shared/execution-host'
 import { basename } from '@/lib/path'
+import { getConnectionId } from '@/lib/connection-context'
+import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
 import { useAppStore } from '@/store'
 import type { OpenFile } from '@/store/slices/editor'
 import { flushPendingEditorChange } from './editor-pending-flush'
+import { resolveRichMarkdownWorktreeRoot } from './useRichMarkdownSuperscriptLinkSetup'
+import type { MarkdownArtifactSource } from './markdown-artifact-document'
 
 export function markdownArtifactSourceKey(file: OpenFile): string {
   const route = file.operationProvenance?.generation.route
@@ -42,6 +46,37 @@ export function markdownArtifactSourceKey(file: OpenFile): string {
  * So the client renders and the server stores. The relay keeps its renderer for
  * clients that still send markdown; nothing about the wire contract changes.
  */
+/**
+ * Where the renderer should go looking for this file's images.
+ *
+ * The same shape the preview builds, from the store rather than from a hook, so
+ * an image that resolves in the preview resolves at share time too — including
+ * on an SSH target or inside a runtime environment, where reading it is an RPC
+ * and not a filesystem call. Without a worktree root there is nothing to
+ * resolve a relative path against, so it falls back to a plain local read.
+ */
+function markdownArtifactImageSource(file: OpenFile): MarkdownArtifactSource {
+  const state = useAppStore.getState()
+  const connectionId = getConnectionId(file.worktreeId)
+  const worktreePath = file.worktreeId
+    ? resolveRichMarkdownWorktreeRoot(state, file.worktreeId)
+    : null
+  if (!file.worktreeId || !worktreePath) {
+    return { filePath: file.filePath, connectionId }
+  }
+  return {
+    filePath: file.filePath,
+    connectionId,
+    runtimeContext: {
+      settings: settingsForRuntimeOwner(state.settings, file.runtimeEnvironmentId),
+      worktreeId: file.worktreeId,
+      worktreePath,
+      connectionId,
+      expectedExternalSshTargetId: file.externalSshTargetId
+    }
+  }
+}
+
 export async function createMarkdownArtifactRequest(
   file: OpenFile,
   content: string
@@ -50,7 +85,11 @@ export async function createMarkdownArtifactRequest(
   const { renderMarkdownArtifactDocument } = await import('./markdown-artifact-document')
   return {
     sourceKey: markdownArtifactSourceKey(file),
-    content: await renderMarkdownArtifactDocument(content, fileName),
+    content: await renderMarkdownArtifactDocument(
+      content,
+      fileName,
+      markdownArtifactImageSource(file)
+    ),
     contentType: 'text/html',
     fileName
   }

--- a/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
+++ b/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
@@ -125,7 +125,7 @@ describe('onboarding feature setup runner', () => {
 
     expect(text).toBe(ALL_SKILL_INSTALL_COMMAND)
     expect(text).toBe(
-      'npx skills add https://github.com/stablyai/manta --skill manta-cli --skill computer-use --skill orchestration --skill manta-linear --global'
+      'npx skills add https://github.com/paidaxingyo666/Manta --skill manta-cli --skill computer-use --skill orchestration --skill manta-linear --global'
     )
   })
 

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
@@ -8,7 +8,7 @@ import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
 import { TooltipProvider } from '../ui/tooltip'
 
 const INSTALL_COMMAND =
-  'npx skills add https://github.com/stablyai/manta --skill manta-cli --global'
+  'npx skills add https://github.com/paidaxingyo666/Manta --skill manta-cli --global'
 const UPDATE_COMMAND = 'npx skills update manta-cli --global'
 
 const mocks = vi.hoisted(() => ({

--- a/src/renderer/src/components/settings/BrowserUseSkillStep.test.tsx
+++ b/src/renderer/src/components/settings/BrowserUseSkillStep.test.tsx
@@ -16,7 +16,7 @@ vi.mock('./AgentSkillSetupPanel', () => ({
 describe('BrowserUseSkillStep', () => {
   it('forwards a single-skill installed command even when setup installs a bundle', () => {
     const bundleInstallCommand =
-      'npx skills add https://github.com/stablyai/manta --skill manta-cli --skill orchestration --global'
+      'npx skills add https://github.com/paidaxingyo666/Manta --skill manta-cli --skill orchestration --global'
     const updateCommand = 'npx skills update manta-cli --global'
 
     renderToStaticMarkup(

--- a/src/renderer/src/components/settings/GeneralSupportSection.tsx
+++ b/src/renderer/src/components/settings/GeneralSupportSection.tsx
@@ -10,7 +10,7 @@ import { SettingsSubsectionHeader } from './SettingsFormControls'
 import { translate } from '@/i18n/i18n'
 
 // Do not deep-link to /stargazers: GitHub 404s that page for users without repo write access.
-const MANTA_GITHUB_URL = 'https://github.com/stablyai/manta'
+const MANTA_GITHUB_URL = 'https://github.com/paidaxingyo666/Manta'
 
 type SupportState =
   | 'loading'

--- a/src/renderer/src/components/settings/OrchestrationPane.test.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.test.tsx
@@ -13,10 +13,10 @@ import { getOrchestrationPaneSearchEntries } from './orchestration-search'
 import { matchesSettingsSearch } from './settings-search'
 
 const INSTALL_COMMAND =
-  'npx skills add https://github.com/stablyai/manta --skill orchestration --global'
+  'npx skills add https://github.com/paidaxingyo666/Manta --skill orchestration --global'
 const UPDATE_COMMAND = INSTALL_COMMAND
 const WINDOWS_INSTALL_COMMAND =
-  'cmd.exe /d /s /c "where.exe npx >nul 2>nul & if errorlevel 1 (echo ERROR: npx was not found. Install Node.js LTS from https://nodejs.org/ to get npx. & echo Then close this terminal and start skill setup again - a new terminal picks up the updated PATH. & exit /b 1) else (npx skills add https://github.com/stablyai/manta --skill orchestration --global)"'
+  'cmd.exe /d /s /c "where.exe npx >nul 2>nul & if errorlevel 1 (echo ERROR: npx was not found. Install Node.js LTS from https://nodejs.org/ to get npx. & echo Then close this terminal and start skill setup again - a new terminal picks up the updated PATH. & exit /b 1) else (npx skills add https://github.com/paidaxingyo666/Manta --skill orchestration --global)"'
 
 const mocks = vi.hoisted(() => ({
   dialogProps: [] as Record<string, unknown>[],

--- a/src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx
+++ b/src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx
@@ -116,7 +116,7 @@ describe('LinearAgentSkillInstallCta', () => {
       'Full guided setup (connect + skill + visibility) is under Settings → Task Sources.'
     )
     expect(rendered.textContent).toContain(
-      'npx skills add https://github.com/stablyai/manta --skill manta-linear --global'
+      'npx skills add https://github.com/paidaxingyo666/Manta --skill manta-linear --global'
     )
   })
 
@@ -130,7 +130,7 @@ describe('LinearAgentSkillInstallCta', () => {
     })
 
     expect(mocks.clipboardWrite).toHaveBeenCalledWith(
-      'npx skills add https://github.com/stablyai/manta --skill manta-linear --global'
+      'npx skills add https://github.com/paidaxingyo666/Manta --skill manta-linear --global'
     )
     expect(mocks.toastSuccess).toHaveBeenCalled()
   })

--- a/src/renderer/src/components/skills/SkillFreshnessUpdateDialog.test.tsx
+++ b/src/renderer/src/components/skills/SkillFreshnessUpdateDialog.test.tsx
@@ -533,7 +533,7 @@ describe('SkillFreshnessUpdateDialog', () => {
     await openViaRequest()
 
     expect(container?.textContent).toContain(
-      'npx skills add https://github.com/stablyai/manta --skill orchestration --global'
+      'npx skills add https://github.com/paidaxingyo666/Manta --skill orchestration --global'
     )
   })
 
@@ -564,7 +564,7 @@ describe('SkillFreshnessUpdateDialog', () => {
 
     const row = container?.querySelector('[data-skill-row="orchestration"]')
     expect(row?.textContent).toContain(
-      'npx skills add https://github.com/stablyai/manta --skill orchestration --global'
+      'npx skills add https://github.com/paidaxingyo666/Manta --skill orchestration --global'
     )
     expect(row?.textContent).not.toContain('This is a project skill, not a global one')
     // Still listed, though — ownership silences the explanation, never the location.

--- a/src/renderer/src/components/skills/skill-freshness-skipped-reason.test.ts
+++ b/src/renderer/src/components/skills/skill-freshness-skipped-reason.test.ts
@@ -40,7 +40,7 @@ describe('skippedReason', () => {
     const reason = skippedReason([row(null)], 'orchestration')
     expect(reason).toContain('reports the skill as already up to date')
     expect(reason).toContain(
-      'npx skills add https://github.com/stablyai/manta --skill orchestration --global'
+      'npx skills add https://github.com/paidaxingyo666/Manta --skill orchestration --global'
     )
   })
 

--- a/src/renderer/src/components/star-nag/StarNagToastHost.test.tsx
+++ b/src/renderer/src/components/star-nag/StarNagToastHost.test.tsx
@@ -159,7 +159,7 @@ describe('StarNagToastHost', () => {
       button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    expect(shell.openUrl).toHaveBeenCalledWith('https://github.com/stablyai/manta')
+    expect(shell.openUrl).toHaveBeenCalledWith('https://github.com/paidaxingyo666/Manta')
     expect(starNag.openWeb).toHaveBeenCalledTimes(1)
     expect(starNag.starManta).not.toHaveBeenCalled()
     expect(toastContainer.textContent).toContain('GitHub opened')

--- a/src/renderer/src/components/star-nag/StarNagToastHost.tsx
+++ b/src/renderer/src/components/star-nag/StarNagToastHost.tsx
@@ -4,7 +4,7 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
 
-const MANTA_REPO_URL = 'https://github.com/stablyai/manta'
+const MANTA_REPO_URL = 'https://github.com/paidaxingyo666/Manta'
 type StarNagMode = 'gh' | 'web'
 type StarNagToastStatus = 'idle' | 'busy' | 'starred' | 'opened'
 

--- a/src/renderer/src/components/stats/ShareUsageButton.tsx
+++ b/src/renderer/src/components/stats/ShareUsageButton.tsx
@@ -110,7 +110,7 @@ export function ShareUsageButton(props: ShareUsageButtonProps): React.JSX.Elemen
       '',
       `${fmtTokens(totalTokens)} tokens · ${costStr} est. cost`,
       '',
-      'github.com/stablyai/manta'
+      'github.com/paidaxingyo666/Manta'
     ]
     const url = `https://x.com/intent/post?text=${encodeURIComponent(lines.join('\n'))}`
     await window.api.shell.openUrl(url)

--- a/src/renderer/src/components/stats/share-card-utils.tsx
+++ b/src/renderer/src/components/stats/share-card-utils.tsx
@@ -215,7 +215,7 @@ export function CardFooter(props: {
         >
           {translate(
             'auto.components.stats.share.card.utils.19f4b4dc75',
-            'github.com/stablyai/manta'
+            'github.com/paidaxingyo666/Manta'
           )}
         </span>
       </div>

--- a/src/shared/agent-feature-install-commands.test.ts
+++ b/src/shared/agent-feature-install-commands.test.ts
@@ -17,24 +17,24 @@ import {
 describe('agent feature skill commands', () => {
   it('builds a global install command by default', () => {
     expect(buildAgentFeatureSkillInstallCommand(['manta-cli'])).toBe(
-      'npx skills add https://github.com/stablyai/manta --skill manta-cli --global'
+      'npx skills add https://github.com/paidaxingyo666/Manta --skill manta-cli --global'
     )
   })
 
   it('drops --global when installing locally', () => {
     expect(buildAgentFeatureSkillInstallCommand(['manta-cli'], { global: false })).toBe(
-      'npx skills add https://github.com/stablyai/manta --skill manta-cli'
+      'npx skills add https://github.com/paidaxingyo666/Manta --skill manta-cli'
     )
   })
 
   it('repeats --skill per name for multi-skill installs', () => {
     expect(buildAgentFeatureSkillInstallCommand(['manta-cli', 'orchestration'])).toBe(
-      'npx skills add https://github.com/stablyai/manta --skill manta-cli --skill orchestration --global'
+      'npx skills add https://github.com/paidaxingyo666/Manta --skill manta-cli --skill orchestration --global'
     )
     expect(buildAgentFeatureSkillInstallArgs(['manta-cli', 'orchestration'])).toEqual([
       'skills',
       'add',
-      'https://github.com/stablyai/manta',
+      'https://github.com/paidaxingyo666/Manta',
       '--skill',
       'manta-cli',
       '--skill',
@@ -76,7 +76,7 @@ describe('agent feature skill commands', () => {
     expect(
       buildAgentFeatureSkillInstallCommand(['manta-cli'], { yes: true, agents: ['universal'] })
     ).toBe(
-      'npx skills add https://github.com/stablyai/manta --skill manta-cli --global --agent universal -y'
+      'npx skills add https://github.com/paidaxingyo666/Manta --skill manta-cli --global --agent universal -y'
     )
     expect(buildAgentFeatureSkillUpdateCommand(['manta-cli'], { global: false, yes: true })).toBe(
       'npx skills update manta-cli --project -y'

--- a/src/shared/agent-feature-install-commands.ts
+++ b/src/shared/agent-feature-install-commands.ts
@@ -1,6 +1,6 @@
 import { isSkillsCliAgentKeyShaped } from './skills-cli-agent-keys'
 
-export const MANTA_SKILLS_REPOSITORY_URL = 'https://github.com/stablyai/manta'
+export const MANTA_SKILLS_REPOSITORY_URL = 'https://github.com/paidaxingyo666/Manta'
 
 export const MANTA_CLI_SKILL_NAME = 'manta-cli'
 export const COMPUTER_USE_SKILL_NAME = 'computer-use'


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​76 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​31 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 |
| Prod | 18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​300 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​272 |

<!-- /manta-pr-loc -->

Three things a shared link got wrong, from three different causes.

## Images never travelled

A shared page is one stored document, so a local image had no way to reach a reader: `file:///Users/…` is the author's alone, and `./shots/a.png` resolves against the artifact origin, which has no such file. Both arrived as a broken image with no hint of why.

The renderer now reads the bytes at share time and inlines them as data URIs, reusing the same resolution the preview uses — so local, SSH and runtime-environment sources all work. It takes two passes: the first only to discover which images the document refers to, because there is no asynchronous step inside react-markdown's pipeline to read them from.

**The rewrite is inserted immediately before the sanitizer, and that order is the whole safety argument.** It only rewrites; what survives into the page is still the sanitizer's decision, so an image that could not be read keeps the `file:` or relative `src` it was written with and is dropped there exactly as before — leaving the alt text, which tells a reader more than a broken-image icon does. Nothing here can widen what a shared page may carry.

Budget is 6 MB of encoded image against the relay's 10 MB artifact ceiling. Anything past it is skipped rather than failing the share.

## No tab icon

Served as a route rather than only declared in `wrapDocument`, because an HTML artifact is published verbatim and never wrapped — the only icon it can pick up is the one a browser asks for on its own at `/favicon.ico`. A route covers both page kinds, and covers **every page already published**, since `wrapDocument` runs at write time and existing bodies are stored.

It sits ahead of the rate limiter on purpose: a browser asks once per page opened, and spending an artifact's budget on its own tab icon is how a reader who followed a few links gets a 429 on the next one.

## Install links named a repository that does not exist

`MANTA_SKILLS_REPOSITORY_URL` read `https://github.com/stablyai/manta` — nobody's. Upstream is `stablyai/orca`; this fork is `paidaxingyo666/Manta`. So the command Settings hands a user to install a skill pointed at a 404. Eleven more places had the same shape: the two star prompts, the support link, the landing page, mobile's "download a newer desktop", the two share texts, and three scripts' fallback repository.

**Only the places the app sends a user are changed.** Historical issue and PR links and test fixtures keep upstream's spelling, which is what they are.

Two things worth recording:

- The current rule already protects every one of these forms — URLs, `.git` suffixes, issue links, `orca-cloud`, `orca-plugins`. Verified each. This is residue from the blind rebrand that preceded the mirror, not something a sync would reintroduce.
- Restoring the test fixtures wholesale looked safe (167 of 202 files become byte-identical to the mirror) and is not: fixtures pair a slug in the input with a bare repository name in the assertion, and moving one side broke 147 tests. Byte-identical to the mirror is not proof a tree passes — the mirror is a mechanical transform and makes no such promise.

## Verification

`sync-verify.sh`: all seven steps green, `SYNC VERIFIED`. Mobile is 4306 tests across 535 files; the touched desktop surface is 439 across 60.