### PR TITLE
fix(relay): let the artifact origin's proxy pass the tab icon through

### DIFF
--- a/relay-server/deploy/Caddyfile
+++ b/relay-server/deploy/Caddyfile
@@ -74,6 +74,17 @@
 #		}
 #	}
 #
+#	# The tab icon has to be named here too. An artifact published as HTML is
+#	# served verbatim and declares no icon, so the browser asks this origin for
+#	# /favicon.ico on its own — and an allowlist that ends in `respond 404`
+#	# answers that itself, however the relay is routed behind it.
+#	@icon path /favicon.ico
+#	handle @icon {
+#		reverse_proxy relay:8787 {
+#			flush_interval -1
+#		}
+#	}
+#
 #	handle {
 #		respond 404
 #	}


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /manta-pr-loc -->

The origin's allowlist ends in `respond 404`, so naming only the published page and the write API meant the proxy answered `/favicon.ico` itself and the relay's route behind it was never reached. An artifact published as HTML is served verbatim and declares no icon, so that request is the only way it can have one.

Found by deploying #36's route to the live relay and watching the icon stay missing. The deployed relay now serves it — this brings the repo's template in line so a fresh deployment does too.

The check that tells the two failure modes apart is the write API: `401` says the proxy forwarded and the relay refused; `404` would have meant the proxy never asked. After the fix the origin answers 200 `image/svg+xml` for the icon, 404 for an unknown slug, 401 for an uncredentialed write, and 404 for `/v1/desktop/auth/*` — the isolation is intact.