### PR TITLE
fix(share): stop the last URL gate from emptying the images just inlined

### DIFF
--- a/docs/release-notes/1.4.199-rc.1.md
+++ b/docs/release-notes/1.4.199-rc.1.md
@@ -1,0 +1,8 @@
+# 1.4.199-rc.1
+
+Shared pages carry their images again.
+
+- An inlined image was emptied by the renderer's last URL check, so the page lost it entirely
+- An image written as an absolute local path was never read at all
+- One that cannot be read now shows its alt text instead of a broken image
+- A file used more than once is read once

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta",
-  "version": "1.4.199-rc.0",
+  "version": "1.4.199-rc.1",
   "description": "Next-gen IDE for parallel agentic development",
   "homepage": "https://github.com/paidaxingyo666/Manta",
   "author": "Manta",

--- a/src/renderer/src/components/editor/markdown-artifact-document.tsx
+++ b/src/renderer/src/components/editor/markdown-artifact-document.tsx
@@ -12,7 +12,7 @@
  * drift, and the promise being made is that the page someone opens is the page
  * the author was looking at.
  */
-import type { Options as ReactMarkdownOptions } from 'react-markdown'
+import { defaultUrlTransform, type Options as ReactMarkdownOptions } from 'react-markdown'
 import {
   MARKDOWN_REHYPE_PLUGINS,
   MARKDOWN_REMARK_PLUGINS,
@@ -86,6 +86,27 @@ function escapeHtml(value: string): string {
 }
 
 /**
+ * The last gate on a URL, and the one that nearly made this pointless.
+ *
+ * react-markdown applies `urlTransform` when it turns the tree into elements —
+ * after every rehype plugin, including the sanitizer — and its default empties
+ * anything that is not http, https, mailto or relative. So a `data:` URI the
+ * inlining step had just written was erased on the way out, and a `file:` src
+ * never survived the discovery pass long enough to be read at all.
+ *
+ * Widening it does not widen what may be published: the share schema has
+ * already removed `file:` by the time this runs, so only a `data:image/` this
+ * code produced can still be here. The discovery pass keeps `file:` because
+ * that pass is thrown away and exists only to find what to read.
+ */
+function shareUrlTransform(value: string, key: string): string {
+  if (key === 'src' && /^(?:data:image\/|file:)/i.test(value)) {
+    return value
+  }
+  return defaultUrlTransform(value)
+}
+
+/**
  * The body, as HTML.
  *
  * `react-dom/server` and `react-markdown` are imported here rather than at the
@@ -102,7 +123,11 @@ export async function renderMarkdownArtifactBody(
   ])
   const render = (inlined: ReadonlyMap<string, string> | null): string =>
     renderToStaticMarkup(
-      <Markdown remarkPlugins={MARKDOWN_REMARK_PLUGINS} rehypePlugins={shareRehypePlugins(inlined)}>
+      <Markdown
+        remarkPlugins={MARKDOWN_REMARK_PLUGINS}
+        rehypePlugins={shareRehypePlugins(inlined)}
+        urlTransform={shareUrlTransform}
+      >
         {markdown}
       </Markdown>
     )

--- a/src/renderer/src/components/editor/markdown-artifact-image-inlining.ts
+++ b/src/renderer/src/components/editor/markdown-artifact-image-inlining.ts
@@ -78,13 +78,20 @@ export async function buildArtifactImageDataUris(
   context: ArtifactImageContext = {}
 ): Promise<Map<string, string>> {
   const inlined = new Map<string, string>()
+  // By absolute path, not by the src as written: `./a.png` and its `file:` form
+  // are the same file, and a document that shows one image four times should
+  // read it once.
+  const byPath = new Map<string, string | null>()
   let budget = MAX_INLINE_BYTES
   for (const src of sources) {
     const absolutePath = resolveImageAbsolutePath(src, filePath)
     if (!absolutePath) {
       continue
     }
-    const dataUri = await readAsDataUri(absolutePath, context)
+    if (!byPath.has(absolutePath)) {
+      byPath.set(absolutePath, await readAsDataUri(absolutePath, context))
+    }
+    const dataUri = byPath.get(absolutePath)
     if (!dataUri || dataUri.length > budget) {
       continue
     }
@@ -120,6 +127,11 @@ export function rehypeInlineArtifactImages(inlined: ReadonlyMap<string, string>)
             const dataUri = inlined.get(src)
             if (dataUri) {
               node.properties.src = dataUri
+            } else if (!isPortable(src)) {
+              // Nothing but artifacts is stored on that origin, so a local path
+              // left here resolves to a 404 and a broken-image icon. Removing it
+              // leaves the alt text, which at least says what is missing.
+              delete node.properties.src
             }
           }
         }

--- a/src/renderer/src/components/editor/markdown-artifact-images.test.ts
+++ b/src/renderer/src/components/editor/markdown-artifact-images.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The shared page's images, asserted on the page itself.
+ *
+ * The parts were covered and the whole was not, and the whole was where it
+ * broke: react-markdown applies `urlTransform` after every rehype plugin, so a
+ * `data:` URI the inlining step had just written was emptied on the way out and
+ * a `file:` src never survived long enough to be read. Every case here goes
+ * through `renderMarkdownArtifactBody` and looks at the HTML, because that is
+ * the only thing a reader ever sees.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/runtime/runtime-file-client', () => ({ readRuntimeFilePreview: vi.fn() }))
+
+const files = new Map<string, string>()
+const readFile = vi.fn(async ({ filePath }: { filePath: string }) => {
+  const content = files.get(filePath)
+  return content === undefined
+    ? { isBinary: false, content: null }
+    : { isBinary: true, content, mimeType: 'image/png' }
+})
+vi.stubGlobal('window', { api: { fs: { readFile } } })
+
+const { renderMarkdownArtifactBody } = await import('./markdown-artifact-document')
+
+const SOURCE = { filePath: '/repo/notes/README.md' }
+const PIXEL = 'iVBORw0KGgoAAAANSUhEUg=='
+
+beforeEach(() => {
+  files.clear()
+  readFile.mockClear()
+})
+
+describe('images on a shared page', () => {
+  it('inlines a relative image the document points at', async () => {
+    files.set('/repo/notes/shots/a.png', PIXEL)
+    const html = await renderMarkdownArtifactBody('![a](./shots/a.png)', SOURCE)
+    expect(html).toContain(`src="data:image/png;base64,${PIXEL}"`)
+  })
+
+  it('inlines one written as raw HTML, which is how a README writes its logo', async () => {
+    files.set('/repo/notes/icon.png', PIXEL)
+    const html = await renderMarkdownArtifactBody('<p><img src="icon.png" alt="logo"></p>', SOURCE)
+    expect(html).toContain(`src="data:image/png;base64,${PIXEL}"`)
+    expect(html).toContain('alt="logo"')
+  })
+
+  it('inlines an absolute file: URL, which the default transform used to empty', async () => {
+    files.set('/repo/notes/a.png', PIXEL)
+    const html = await renderMarkdownArtifactBody('![a](file:///repo/notes/a.png)', SOURCE)
+    expect(html).toContain(`src="data:image/png;base64,${PIXEL}"`)
+  })
+
+  it('reads a file once however many times and however it is spelled', async () => {
+    files.set('/repo/notes/a.png', PIXEL)
+    await renderMarkdownArtifactBody(
+      '![one](./a.png)\n\n![two](./a.png)\n\n![three](file:///repo/notes/a.png)',
+      SOURCE
+    )
+    expect(readFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves a remote image exactly as written', async () => {
+    const html = await renderMarkdownArtifactBody('![r](https://x.test/b.png)', SOURCE)
+    expect(html).toContain('src="https://x.test/b.png"')
+    expect(readFile).not.toHaveBeenCalled()
+  })
+
+  it('drops the src of one it could not read, so the alt text shows instead', async () => {
+    const html = await renderMarkdownArtifactBody('![gone](./missing.png)', SOURCE)
+    expect(html).toContain('alt="gone"')
+    expect(html).not.toContain('missing.png')
+    expect(html).not.toContain('src=')
+  })
+
+  it('never leaves a file: URL on the page, read or not', async () => {
+    const html = await renderMarkdownArtifactBody(
+      '![gone](file:///Users/someone/private/a.png)',
+      SOURCE
+    )
+    expect(html).not.toContain('file:')
+    expect(html).not.toContain('/Users/someone')
+  })
+
+  it('stops at the budget rather than failing the share', async () => {
+    // Two images either side of what a page may carry: the first fits, the
+    // second does not, and the page still renders with both alt texts.
+    files.set('/repo/notes/big.png', 'A'.repeat(5 * 1024 * 1024))
+    files.set('/repo/notes/bigger.png', 'B'.repeat(5 * 1024 * 1024))
+    const html = await renderMarkdownArtifactBody(
+      '![first](./big.png)\n\n![second](./bigger.png)',
+      SOURCE
+    )
+    expect(html).toContain('data:image/png;base64,AAA')
+    expect(html).not.toContain('data:image/png;base64,BBB')
+    expect(html).toContain('alt="second"')
+  })
+
+  it('drops local images when nothing says where the document lives', async () => {
+    // Same answer as an unreadable one, and for the same reason: without a
+    // source path there is nothing to resolve a relative image against, so the
+    // page cannot carry it and must not pretend to.
+    const html = await renderMarkdownArtifactBody('![a](./shots/a.png)')
+    expect(readFile).not.toHaveBeenCalled()
+    expect(html).toContain('alt="a"')
+    expect(html).not.toContain('src=')
+  })
+})


### PR DESCRIPTION
<!-- manta-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​108 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​108 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 |

<!-- /manta-pr-loc -->

Cuts `1.4.199-rc.1`. Merging it tags and builds.

## What was wrong

react-markdown applies `urlTransform` when it turns the tree into elements — **after every rehype plugin, including the sanitizer** — and its default empties anything that is not http, https, mailto or relative.

So the `data:` URI the inlining step had just written was erased on the way out, and the page lost the image's `src` entirely. That is worse than before the feature existed, where a relative path at least stayed and 404'd. The same gate emptied `file:` during the discovery pass, so an image written as an absolute local URL was never read at all.

Reproduced against the HTML of a page shared from `1.4.199-rc.0`: the renderer's output matches it character for character.

## Why widening it is safe

The share schema removes `file:` before `urlTransform` runs, so the only thing that can still be there is a `data:image/` this code produced. The discovery pass keeps `file:` because that pass is thrown away and exists only to find what to read.

## Also

- A local `src` that could not be inlined is now removed rather than left to 404 as a broken image — which is what the code already claimed it did.
- A file referred to twice is read once.

## The gap that let it through

Every part was covered — discovery, reading, the rewrite plugin — and the whole was not, which is exactly where it broke. Nine cases now go through `renderMarkdownArtifactBody` and assert the HTML, because that is the only thing a reader ever sees: relative, raw-HTML (how a README writes its logo), `file:` absolute, repeated references, remote left alone, unreadable falling back to alt text, no `file:` path ever reaching the page, and the size budget.

`sync-verify.sh`: all seven steps green.